### PR TITLE
Update fetcher to pull from correct repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,7 +378,7 @@ Note: Going forward we won't be shipping the point releases for each distro. Ins
   - Solaris 5.10
   - Windows 7
 
-For a list of currently support platform releases see https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md
+For a list of currently support platform releases see https://github.com/chef/fauxhai/blob/master/PLATFORMS.md
 
 ## v6.11.0 (2018-01-30)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Fauxhai
 
-Fauxhai is community-maintained and updated. Aside from the initial files, all of the ohai system mocks have been created by the community. If you have a system that you think would benefit the community, here's how you get it into [fauxhai](https://github.com/chefspec/fauxhai):
+Fauxhai is community-maintained and updated. Aside from the initial files, all of the ohai system mocks have been created by the community. If you have a system that you think would benefit the community, here's how you get it into [fauxhai](https://github.com/chef/fauxhai):
 
 1. Build a system to your liking (on a virtual machine, for example)
 2. Install chef, ohai, and fauxhai

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fauxhai-ng
 
-![CI](https://github.com/chefspec/fauxhai/workflows/CI/badge.svg) [![Gem Version](https://badge.fury.io/rb/fauxhai-ng.svg)](https://badge.fury.io/rb/fauxhai-ng)
+![CI](https://github.com/chef/fauxhai/workflows/CI/badge.svg) [![Gem Version](https://badge.fury.io/rb/fauxhai-ng.svg)](https://badge.fury.io/rb/fauxhai-ng)
 
 Note: fauxhai-ng is an updated version of the original fauxhai gem. The CLI and library namespaces have not changed, but you will want to update to use the new gem.
 

--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -4,10 +4,10 @@ require "pathname" unless defined?(Pathname)
 module Fauxhai
   class Mocker
     # The base URL for the GitHub project (raw)
-    RAW_BASE = "https://raw.githubusercontent.com/chefspec/fauxhai/master".freeze
+    RAW_BASE = "https://raw.githubusercontent.com/chef/fauxhai/main".freeze
 
     # A message about where to find a list of platforms
-    PLATFORM_LIST_MESSAGE = "A list of available platforms is available at https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md".freeze
+    PLATFORM_LIST_MESSAGE = "A list of available platforms is available at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md".freeze
 
     # Create a new Ohai Mock with fauxhai.
     #


### PR DESCRIPTION
The fetcher is still trying to pull from the chefspec org which is no longer being maintained. This updates it so that we pull any new platforms that haven't been released can still be pulled.

In addition, update any remaining references to do the old chefspec org.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
