### PR TITLE
Add Ubuntu 22.04 (jammy) support

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -126,6 +126,7 @@ This file lists each platform known to Fauxhai and the available versions for ea
 - 16.04
 - 18.04
 - 20.04
+- 22.04
 
 ### windows
 

--- a/lib/fauxhai/platforms/ubuntu/22.04.json
+++ b/lib/fauxhai/platforms/ubuntu/22.04.json
@@ -1,0 +1,4578 @@
+{
+  "block_device": {
+    "dm-0": {
+      "size": "65003520",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop0": {
+      "size": "126760",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop1": {
+      "size": "163736",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop2": {
+      "size": "91496",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop3": {
+      "size": "98288",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop4": {
+      "size": "129480",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop5": {
+      "size": "210912",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop6": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop7": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "sda": {
+      "size": "134217728",
+      "removable": "0",
+      "model": "VBOX HARDDISK",
+      "rev": "1.0",
+      "state": "running",
+      "timeout": "30",
+      "vendor": "ATA",
+      "queue_depth": "32",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    }
+  },
+  "chef_packages": {
+    "ohai": {
+      "version": "18.0.14",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-18.0.14/lib/ohai"
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "lo": {
+          "tx": {
+            "queuelen": "1",
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "carrier": 0,
+            "collisions": 0
+          },
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0
+          }
+        },
+        "eth0": {
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "collisions": 0,
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "current_user": "fauxhai",
+  "dmi": {
+    "dmidecode_version": "3.3",
+    "smbios_version": "2.5",
+    "structures": {
+      "count": "10",
+      "size": "450"
+    },
+    "table_location": "0x000E1000",
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "innotek GmbH",
+          "Version": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address": "0xE0000",
+          "Runtime Size": "128 kB",
+          "ROM Size": "128 kB",
+          "Characteristics": {
+            "ACPI is supported": null
+          }
+        }
+      ],
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address": "0xE0000",
+      "runtime_size": "128 kB",
+      "rom_size": "128 kB"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0001",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "innotek GmbH",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "231327bb-cb5a-504c-a1ac-eb947d65856e",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Virtual Machine"
+        }
+      ],
+      "manufacturer": "innotek GmbH",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "231327bb-cb5a-504c-a1ac-eb947d65856e",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0003",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Oracle Corporation",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "None"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "None"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "vboxVer_6.1.38",
+          "String 2": "vboxRev_153438"
+        }
+      ],
+      "string_1": "vboxVer_6.1.38",
+      "string_2": "vboxRev_153438"
+    }
+  },
+  "domain": "local",
+  "filesystem": {
+    "by_device": {
+      "tmpfs": {
+        "kb_size": "99428",
+        "kb_used": "4",
+        "kb_available": "99424",
+        "percent_used": "1%",
+        "total_inodes": "24857",
+        "inodes_used": "25",
+        "inodes_available": "24832",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=99432k",
+          "mode=755",
+          "inode64"
+        ],
+        "mounts": [
+          "/run",
+          "/dev/shm",
+          "/run/lock",
+          "/run/user/1000",
+          "/run/snapd/ns"
+        ]
+      },
+      "/dev/mapper/ubuntu--vg-ubuntu--lv": {
+        "kb_size": "31811408",
+        "kb_used": "6465824",
+        "kb_available": "23704112",
+        "percent_used": "22%",
+        "total_inodes": "2031616",
+        "inodes_used": "55631",
+        "inodes_available": "1975985",
+        "inodes_percent_used": "3%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "b50fc2f6-3b6c-4bfb-a3d9-bd9a127ad072",
+        "mounts": [
+          "/"
+        ]
+      },
+      "/dev/sda2": {
+        "kb_size": "1992552",
+        "kb_used": "128480",
+        "kb_available": "1742832",
+        "percent_used": "7%",
+        "total_inodes": "131072",
+        "inodes_used": "316",
+        "inodes_available": "130756",
+        "inodes_percent_used": "1%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "27b9d749-1470-4a8c-b837-2daab86aad8d",
+        "mounts": [
+          "/boot"
+        ]
+      },
+      "tmp_omnibus_cache": {
+        "kb_size": "958045344",
+        "kb_used": "672743784",
+        "kb_available": "285301560",
+        "percent_used": "71%",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ],
+        "mounts": [
+          "/tmp/omnibus/cache"
+        ]
+      },
+      "sysfs": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys"
+        ]
+      },
+      "proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc"
+        ]
+      },
+      "udev": {
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=440868k",
+          "nr_inodes=110217",
+          "mode=755",
+          "inode64"
+        ],
+        "mounts": [
+          "/dev"
+        ]
+      },
+      "devpts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "mounts": [
+          "/dev/pts"
+        ]
+      },
+      "securityfs": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/security"
+        ]
+      },
+      "cgroup2": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup"
+        ]
+      },
+      "pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/pstore"
+        ]
+      },
+      "bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/sys/fs/bpf"
+        ]
+      },
+      "systemd-1": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=29",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18664"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "hugetlbfs": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "mounts": [
+          "/dev/hugepages"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/dev/mqueue"
+        ]
+      },
+      "debugfs": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/debug"
+        ]
+      },
+      "tracefs": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/tracing",
+          "/sys/kernel/debug/tracing"
+        ]
+      },
+      "fusectl": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/fuse/connections"
+        ]
+      },
+      "configfs": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/config"
+        ]
+      },
+      "none": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/run/credentials/systemd-sysusers.service"
+        ]
+      },
+      "/var/lib/snapd/snaps/core20_1405.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/core20/1405"
+        ]
+      },
+      "/var/lib/snapd/snaps/lxd_22923.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/lxd/22923"
+        ]
+      },
+      "/var/lib/snapd/snaps/snapd_15534.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/snapd/15534"
+        ]
+      },
+      "/var/lib/snapd/snaps/snapd_16778.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/snapd/16778"
+        ]
+      },
+      "/var/lib/snapd/snaps/core20_1623.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/core20/1623"
+        ]
+      },
+      "/var/lib/snapd/snaps/lxd_23541.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/lxd/23541"
+        ]
+      },
+      "nsfs": {
+        "fs_type": "nsfs",
+        "mount_options": [
+          "rw"
+        ],
+        "mounts": [
+          "/run/snapd/ns/lxd.mnt"
+        ]
+      },
+      "binfmt_misc": {
+        "fs_type": "binfmt_misc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "/dev/loop0": {
+        "fs_type": "squashfs",
+        "mounts": [
+          "/snap/core20/1405"
+        ],
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop1": {
+        "fs_type": "squashfs",
+        "mounts": [
+          "/snap/lxd/22923"
+        ],
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop2": {
+        "fs_type": "squashfs",
+        "mounts": [
+          "/snap/snapd/15534"
+        ],
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop3": {
+        "fs_type": "squashfs",
+        "mounts": [
+          "/snap/snapd/16778"
+        ],
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop4": {
+        "fs_type": "squashfs",
+        "mounts": [
+          "/snap/core20/1623"
+        ],
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop5": {
+        "fs_type": "squashfs",
+        "mounts": [
+          "/snap/lxd/23541"
+        ],
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/sda": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/sda1": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/sda3": {
+        "fs_type": "LVM2_member",
+        "uuid": "jIfuRV-7jQb-LJLT-lY2e-0Zu3-7Zel-hDLywi",
+        "mounts": [
+
+        ]
+      }
+    },
+    "by_mountpoint": {
+      "/run": {
+        "kb_size": "99432",
+        "kb_used": "968",
+        "kb_available": "98464",
+        "percent_used": "1%",
+        "total_inodes": "124287",
+        "inodes_used": "708",
+        "inodes_available": "123579",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=99432k",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/": {
+        "kb_size": "31811408",
+        "kb_used": "6465824",
+        "kb_available": "23704112",
+        "percent_used": "22%",
+        "total_inodes": "2031616",
+        "inodes_used": "55631",
+        "inodes_available": "1975985",
+        "inodes_percent_used": "3%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "b50fc2f6-3b6c-4bfb-a3d9-bd9a127ad072",
+        "devices": [
+          "/dev/mapper/ubuntu--vg-ubuntu--lv"
+        ]
+      },
+      "/dev/shm": {
+        "kb_size": "497148",
+        "kb_used": "0",
+        "kb_available": "497148",
+        "percent_used": "0%",
+        "total_inodes": "124287",
+        "inodes_used": "1",
+        "inodes_available": "124286",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/run/lock": {
+        "kb_size": "5120",
+        "kb_used": "0",
+        "kb_available": "5120",
+        "percent_used": "0%",
+        "total_inodes": "124287",
+        "inodes_used": "3",
+        "inodes_available": "124284",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/boot": {
+        "kb_size": "1992552",
+        "kb_used": "128480",
+        "kb_available": "1742832",
+        "percent_used": "7%",
+        "total_inodes": "131072",
+        "inodes_used": "316",
+        "inodes_available": "130756",
+        "inodes_percent_used": "1%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "27b9d749-1470-4a8c-b837-2daab86aad8d",
+        "devices": [
+          "/dev/sda2"
+        ]
+      },
+      "/tmp/omnibus/cache": {
+        "kb_size": "958045344",
+        "kb_used": "672743784",
+        "kb_available": "285301560",
+        "percent_used": "71%",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ],
+        "devices": [
+          "tmp_omnibus_cache"
+        ]
+      },
+      "/run/user/1000": {
+        "kb_size": "99428",
+        "kb_used": "4",
+        "kb_available": "99424",
+        "percent_used": "1%",
+        "total_inodes": "24857",
+        "inodes_used": "25",
+        "inodes_available": "24832",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=99428k",
+          "nr_inodes=24857",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/sys": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "sysfs"
+        ]
+      },
+      "/proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "proc"
+        ]
+      },
+      "/dev": {
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=440868k",
+          "nr_inodes=110217",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "udev"
+        ]
+      },
+      "/dev/pts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "devices": [
+          "devpts"
+        ]
+      },
+      "/sys/kernel/security": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "securityfs"
+        ]
+      },
+      "/sys/fs/cgroup": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ],
+        "devices": [
+          "cgroup2"
+        ]
+      },
+      "/sys/fs/pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "pstore"
+        ]
+      },
+      "/sys/fs/bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "devices": [
+          "bpf"
+        ]
+      },
+      "/proc/sys/fs/binfmt_misc": {
+        "fs_type": "binfmt_misc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "systemd-1",
+          "binfmt_misc"
+        ]
+      },
+      "/dev/hugepages": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "devices": [
+          "hugetlbfs"
+        ]
+      },
+      "/dev/mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "mqueue"
+        ]
+      },
+      "/sys/kernel/debug": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "debugfs"
+        ]
+      },
+      "/sys/kernel/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "tracefs"
+        ]
+      },
+      "/sys/fs/fuse/connections": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "fusectl"
+        ]
+      },
+      "/sys/kernel/config": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "configfs"
+        ]
+      },
+      "/run/credentials/systemd-sysusers.service": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/snap/core20/1405": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ],
+        "devices": [
+          "/var/lib/snapd/snaps/core20_1405.snap",
+          "/dev/loop0"
+        ]
+      },
+      "/snap/lxd/22923": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ],
+        "devices": [
+          "/var/lib/snapd/snaps/lxd_22923.snap",
+          "/dev/loop1"
+        ]
+      },
+      "/snap/snapd/15534": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ],
+        "devices": [
+          "/var/lib/snapd/snaps/snapd_15534.snap",
+          "/dev/loop2"
+        ]
+      },
+      "/run/snapd/ns": {
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=99432k",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/snap/snapd/16778": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ],
+        "devices": [
+          "/var/lib/snapd/snaps/snapd_16778.snap",
+          "/dev/loop3"
+        ]
+      },
+      "/snap/core20/1623": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ],
+        "devices": [
+          "/var/lib/snapd/snaps/core20_1623.snap",
+          "/dev/loop4"
+        ]
+      },
+      "/snap/lxd/23541": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ],
+        "devices": [
+          "/var/lib/snapd/snaps/lxd_23541.snap",
+          "/dev/loop5"
+        ]
+      },
+      "/run/snapd/ns/lxd.mnt": {
+        "fs_type": "nsfs",
+        "mount_options": [
+          "rw"
+        ],
+        "devices": [
+          "nsfs"
+        ]
+      },
+      "/sys/kernel/debug/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "tracefs"
+        ]
+      }
+    },
+    "by_pair": {
+      "tmpfs,/run": {
+        "device": "tmpfs",
+        "kb_size": "99432",
+        "kb_used": "968",
+        "kb_available": "98464",
+        "percent_used": "1%",
+        "mount": "/run",
+        "total_inodes": "124287",
+        "inodes_used": "708",
+        "inodes_available": "123579",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=99432k",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "/dev/mapper/ubuntu--vg-ubuntu--lv,/": {
+        "device": "/dev/mapper/ubuntu--vg-ubuntu--lv",
+        "kb_size": "31811408",
+        "kb_used": "6465824",
+        "kb_available": "23704112",
+        "percent_used": "22%",
+        "mount": "/",
+        "total_inodes": "2031616",
+        "inodes_used": "55631",
+        "inodes_available": "1975985",
+        "inodes_percent_used": "3%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "b50fc2f6-3b6c-4bfb-a3d9-bd9a127ad072"
+      },
+      "tmpfs,/dev/shm": {
+        "device": "tmpfs",
+        "kb_size": "497148",
+        "kb_used": "0",
+        "kb_available": "497148",
+        "percent_used": "0%",
+        "mount": "/dev/shm",
+        "total_inodes": "124287",
+        "inodes_used": "1",
+        "inodes_available": "124286",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "inode64"
+        ]
+      },
+      "tmpfs,/run/lock": {
+        "device": "tmpfs",
+        "kb_size": "5120",
+        "kb_used": "0",
+        "kb_available": "5120",
+        "percent_used": "0%",
+        "mount": "/run/lock",
+        "total_inodes": "124287",
+        "inodes_used": "3",
+        "inodes_available": "124284",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k",
+          "inode64"
+        ]
+      },
+      "/dev/sda2,/boot": {
+        "device": "/dev/sda2",
+        "kb_size": "1992552",
+        "kb_used": "128480",
+        "kb_available": "1742832",
+        "percent_used": "7%",
+        "mount": "/boot",
+        "total_inodes": "131072",
+        "inodes_used": "316",
+        "inodes_available": "130756",
+        "inodes_percent_used": "1%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "27b9d749-1470-4a8c-b837-2daab86aad8d"
+      },
+      "tmp_omnibus_cache,/tmp/omnibus/cache": {
+        "device": "tmp_omnibus_cache",
+        "kb_size": "958045344",
+        "kb_used": "672743784",
+        "kb_available": "285301560",
+        "percent_used": "71%",
+        "mount": "/tmp/omnibus/cache",
+        "fs_type": "vboxsf",
+        "mount_options": [
+          "rw",
+          "nodev",
+          "relatime",
+          "iocharset=utf8",
+          "uid=1000",
+          "gid=1000",
+          "_netdev"
+        ]
+      },
+      "tmpfs,/run/user/1000": {
+        "device": "tmpfs",
+        "kb_size": "99428",
+        "kb_used": "4",
+        "kb_available": "99424",
+        "percent_used": "1%",
+        "mount": "/run/user/1000",
+        "total_inodes": "24857",
+        "inodes_used": "25",
+        "inodes_available": "24832",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=99428k",
+          "nr_inodes=24857",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ]
+      },
+      "sysfs,/sys": {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "proc,/proc": {
+        "device": "proc",
+        "mount": "/proc",
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "udev,/dev": {
+        "device": "udev",
+        "mount": "/dev",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=440868k",
+          "nr_inodes=110217",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "devpts,/dev/pts": {
+        "device": "devpts",
+        "mount": "/dev/pts",
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "securityfs,/sys/kernel/security": {
+        "device": "securityfs",
+        "mount": "/sys/kernel/security",
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "cgroup2,/sys/fs/cgroup": {
+        "device": "cgroup2",
+        "mount": "/sys/fs/cgroup",
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ]
+      },
+      "pstore,/sys/fs/pstore": {
+        "device": "pstore",
+        "mount": "/sys/fs/pstore",
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "bpf,/sys/fs/bpf": {
+        "device": "bpf",
+        "mount": "/sys/fs/bpf",
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "systemd-1,/proc/sys/fs/binfmt_misc": {
+        "device": "systemd-1",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=29",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18664"
+        ]
+      },
+      "hugetlbfs,/dev/hugepages": {
+        "device": "hugetlbfs",
+        "mount": "/dev/hugepages",
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "mount": "/dev/mqueue",
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "debugfs,/sys/kernel/debug": {
+        "device": "debugfs",
+        "mount": "/sys/kernel/debug",
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "tracefs,/sys/kernel/tracing": {
+        "device": "tracefs",
+        "mount": "/sys/kernel/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "fusectl,/sys/fs/fuse/connections": {
+        "device": "fusectl",
+        "mount": "/sys/fs/fuse/connections",
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "configfs,/sys/kernel/config": {
+        "device": "configfs",
+        "mount": "/sys/kernel/config",
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "none,/run/credentials/systemd-sysusers.service": {
+        "device": "none",
+        "mount": "/run/credentials/systemd-sysusers.service",
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "/var/lib/snapd/snaps/core20_1405.snap,/snap/core20/1405": {
+        "device": "/var/lib/snapd/snaps/core20_1405.snap",
+        "mount": "/snap/core20/1405",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ]
+      },
+      "/var/lib/snapd/snaps/lxd_22923.snap,/snap/lxd/22923": {
+        "device": "/var/lib/snapd/snaps/lxd_22923.snap",
+        "mount": "/snap/lxd/22923",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ]
+      },
+      "/var/lib/snapd/snaps/snapd_15534.snap,/snap/snapd/15534": {
+        "device": "/var/lib/snapd/snaps/snapd_15534.snap",
+        "mount": "/snap/snapd/15534",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ]
+      },
+      "tmpfs,/run/snapd/ns": {
+        "device": "tmpfs",
+        "mount": "/run/snapd/ns",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=99432k",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "/var/lib/snapd/snaps/snapd_16778.snap,/snap/snapd/16778": {
+        "device": "/var/lib/snapd/snaps/snapd_16778.snap",
+        "mount": "/snap/snapd/16778",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ]
+      },
+      "/var/lib/snapd/snaps/core20_1623.snap,/snap/core20/1623": {
+        "device": "/var/lib/snapd/snaps/core20_1623.snap",
+        "mount": "/snap/core20/1623",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ]
+      },
+      "/var/lib/snapd/snaps/lxd_23541.snap,/snap/lxd/23541": {
+        "device": "/var/lib/snapd/snaps/lxd_23541.snap",
+        "mount": "/snap/lxd/23541",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue",
+          "x-gdu.hide"
+        ]
+      },
+      "nsfs,/run/snapd/ns/lxd.mnt": {
+        "device": "nsfs",
+        "mount": "/run/snapd/ns/lxd.mnt",
+        "fs_type": "nsfs",
+        "mount_options": [
+          "rw"
+        ]
+      },
+      "binfmt_misc,/proc/sys/fs/binfmt_misc": {
+        "device": "binfmt_misc",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "binfmt_misc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "tracefs,/sys/kernel/debug/tracing": {
+        "device": "tracefs",
+        "mount": "/sys/kernel/debug/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/dev/loop0,": {
+        "device": "/dev/loop0",
+        "fs_type": "squashfs"
+      },
+      "/dev/loop1,": {
+        "device": "/dev/loop1",
+        "fs_type": "squashfs"
+      },
+      "/dev/loop2,": {
+        "device": "/dev/loop2",
+        "fs_type": "squashfs"
+      },
+      "/dev/loop3,": {
+        "device": "/dev/loop3",
+        "fs_type": "squashfs"
+      },
+      "/dev/loop4,": {
+        "device": "/dev/loop4",
+        "fs_type": "squashfs"
+      },
+      "/dev/loop5,": {
+        "device": "/dev/loop5",
+        "fs_type": "squashfs"
+      },
+      "/dev/sda,": {
+        "device": "/dev/sda"
+      },
+      "/dev/sda1,": {
+        "device": "/dev/sda1"
+      },
+      "/dev/sda3,": {
+        "device": "/dev/sda3",
+        "fs_type": "LVM2_member",
+        "uuid": "jIfuRV-7jQb-LJLT-lY2e-0Zu3-7Zel-hDLywi"
+      },
+      "/dev/loop0,/snap/core20/1405": {
+        "device": "/dev/loop0",
+        "mount": "/snap/core20/1405",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop1,/snap/lxd/22923": {
+        "device": "/dev/loop1",
+        "mount": "/snap/lxd/22923",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop2,/snap/snapd/15534": {
+        "device": "/dev/loop2",
+        "mount": "/snap/snapd/15534",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop3,/snap/snapd/16778": {
+        "device": "/dev/loop3",
+        "mount": "/snap/snapd/16778",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop4,/snap/core20/1623": {
+        "device": "/dev/loop4",
+        "mount": "/snap/core20/1623",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      },
+      "/dev/loop5,/snap/lxd/23541": {
+        "device": "/dev/loop5",
+        "mount": "/snap/lxd/23541",
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "errors=continue"
+        ]
+      }
+    }
+  },
+  "fips": {
+    "kernel": {
+      "enabled": true
+    }
+  },
+  "fqdn": "fauxhai.local",
+  "hostname": "Fauxhai",
+  "idle": "30 days 15 hours 07 minutes 30 seconds",
+  "idletime_seconds": 2646450,
+  "init_package": "systemd",
+  "ipaddress": "10.0.0.2",
+  "kernel": {
+    "name": "Linux",
+    "release": "5.15.0-30-generic",
+    "version": "#31-Ubuntu SMP Thu May 5 10:00:34 UTC 2022",
+    "machine": "x86_64",
+    "processor": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "binfmt_misc": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "tls": {
+        "size": "106496",
+        "refcount": "0"
+      },
+      "vboxsf": {
+        "size": "77824",
+        "refcount": "1",
+        "version": "6.1.34 r150636"
+      },
+      "intel_rapl_msr": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "intel_rapl_common": {
+        "size": "36864",
+        "refcount": "1"
+      },
+      "rapl": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "input_leds": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "vboxguest": {
+        "size": "401408",
+        "refcount": "2",
+        "version": "6.1.34 r150636"
+      },
+      "mac_hid": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "sch_fq_codel": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "dm_multipath": {
+        "size": "40960",
+        "refcount": "0"
+      },
+      "scsi_dh_rdac": {
+        "size": "20480",
+        "refcount": "0",
+        "version": "01.00.0000.0000"
+      },
+      "scsi_dh_emc": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "scsi_dh_alua": {
+        "size": "20480",
+        "refcount": "0",
+        "version": "2.0"
+      },
+      "ipmi_devintf": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "ipmi_msghandler": {
+        "size": "122880",
+        "refcount": "1",
+        "version": "39.2"
+      },
+      "msr": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ip_tables": {
+        "size": "32768",
+        "refcount": "0"
+      },
+      "x_tables": {
+        "size": "53248",
+        "refcount": "1"
+      },
+      "autofs4": {
+        "size": "49152",
+        "refcount": "2"
+      },
+      "btrfs": {
+        "size": "1523712",
+        "refcount": "0"
+      },
+      "blake2b_generic": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "zstd_compress": {
+        "size": "229376",
+        "refcount": "1"
+      },
+      "raid10": {
+        "size": "69632",
+        "refcount": "0"
+      },
+      "raid456": {
+        "size": "163840",
+        "refcount": "0"
+      },
+      "async_raid6_recov": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "async_memcpy": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "async_pq": {
+        "size": "24576",
+        "refcount": "2"
+      },
+      "async_xor": {
+        "size": "20480",
+        "refcount": "3"
+      },
+      "async_tx": {
+        "size": "20480",
+        "refcount": "5"
+      },
+      "xor": {
+        "size": "24576",
+        "refcount": "2"
+      },
+      "raid6_pq": {
+        "size": "122880",
+        "refcount": "4"
+      },
+      "libcrc32c": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "raid1": {
+        "size": "49152",
+        "refcount": "0"
+      },
+      "raid0": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "multipath": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "linear": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "vboxvideo": {
+        "size": "36864",
+        "refcount": "1",
+        "version": "6.1.34 r150636"
+      },
+      "drm_ttm_helper": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "crct10dif_pclmul": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ttm": {
+        "size": "86016",
+        "refcount": "2"
+      },
+      "crc32_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "drm_kms_helper": {
+        "size": "307200",
+        "refcount": "1"
+      },
+      "syscopyarea": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysfillrect": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "sysimgblt": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "fb_sys_fops": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "aesni_intel": {
+        "size": "376832",
+        "refcount": "0"
+      },
+      "crypto_simd": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "cec": {
+        "size": "61440",
+        "refcount": "1"
+      },
+      "cryptd": {
+        "size": "24576",
+        "refcount": "2"
+      },
+      "rc_core": {
+        "size": "65536",
+        "refcount": "1"
+      },
+      "ahci": {
+        "size": "45056",
+        "refcount": "2",
+        "version": "3.0"
+      },
+      "drm": {
+        "size": "606208",
+        "refcount": "5"
+      },
+      "e1000": {
+        "size": "155648",
+        "refcount": "0"
+      },
+      "libahci": {
+        "size": "45056",
+        "refcount": "1"
+      },
+      "psmouse": {
+        "size": "176128",
+        "refcount": "0"
+      },
+      "pata_acpi": {
+        "size": "16384",
+        "refcount": "0",
+        "version": "0.2.3"
+      },
+      "i2c_piix4": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "video": {
+        "size": "53248",
+        "refcount": "0"
+      }
+    }
+  },
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "3.0.3",
+      "release_date": "2021-11-24",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems"
+    },
+    "powershell": null
+  },
+  "lsb": {
+    "id": "Ubuntu",
+    "description": "Ubuntu 22.04 LTS",
+    "release": "22.04",
+    "codename": "jammy"
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "machinename": "Fauxhai",
+  "memory": {
+    "total": "1048576kB"
+  },
+  "network": {
+    "interfaces": {
+      "lo": {
+        "mtu": "65536",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Loopback",
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "prefixlen": "8",
+            "netmask": "255.0.0.0",
+            "scope": "Node",
+            "ip_scope": "LOOPBACK"
+          },
+          "::1": {
+            "family": "inet6",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL LOOPBACK"
+          }
+        },
+        "state": "unknown"
+      },
+      "eth0": {
+        "type": "eth",
+        "number": "0",
+        "mtu": "1500",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Ethernet",
+        "addresses": {
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
+          },
+          "10.0.0.2": {
+            "family": "inet",
+            "prefixlen": "24",
+            "netmask": "255.255.255.0",
+            "broadcast": "10.0.0.255",
+            "scope": "Global",
+            "ip_scope": "RFC1918 PRIVATE"
+          },
+          "fe80::11:1111:1111:1111": {
+            "family": "inet6",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL UNICAST"
+          }
+        },
+        "state": "up",
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "10.0.0.1"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
+            "scope": "link",
+            "proto": "kernel",
+            "src": "10.0.0.2"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ],
+        "ring_params": {
+        }
+      }
+    },
+    "default_interface": "eth0",
+    "default_gateway": "10.0.0.1"
+  },
+  "ohai_time": 1664245019.8239367,
+  "os": "linux",
+  "os_version": "5.15.0-30-generic",
+  "packages": {
+    "adduser": {
+      "version": "3.118ubuntu5",
+      "arch": "all"
+    },
+    "amd64-microcode": {
+      "version": "3.20191218.1ubuntu2",
+      "arch": "amd64"
+    },
+    "apparmor": {
+      "version": "3.0.4-2ubuntu2",
+      "arch": "amd64"
+    },
+    "apport": {
+      "version": "2.20.11-0ubuntu82.1",
+      "arch": "all"
+    },
+    "apport-symptoms": {
+      "version": "0.24",
+      "arch": "all"
+    },
+    "apt": {
+      "version": "2.4.5",
+      "arch": "amd64"
+    },
+    "apt-utils": {
+      "version": "2.4.5",
+      "arch": "amd64"
+    },
+    "base-files": {
+      "version": "12ubuntu4.1",
+      "arch": "amd64"
+    },
+    "base-passwd": {
+      "version": "3.5.52build1",
+      "arch": "amd64"
+    },
+    "bash": {
+      "version": "5.1-6ubuntu1",
+      "arch": "amd64"
+    },
+    "bc": {
+      "version": "1.07.1-3build1",
+      "arch": "amd64"
+    },
+    "bcache-tools": {
+      "version": "1.0.8-4ubuntu3",
+      "arch": "amd64"
+    },
+    "bind9-dnsutils": {
+      "version": "1:9.18.1-1ubuntu1.1",
+      "arch": "amd64"
+    },
+    "bind9-host": {
+      "version": "1:9.18.1-1ubuntu1.1",
+      "arch": "amd64"
+    },
+    "bind9-libs": {
+      "version": "1:9.18.1-1ubuntu1.1",
+      "arch": "amd64"
+    },
+    "binutils": {
+      "version": "2.38-3ubuntu1",
+      "arch": "amd64"
+    },
+    "binutils-common": {
+      "version": "2.38-3ubuntu1",
+      "arch": "amd64"
+    },
+    "binutils-x86-64-linux-gnu": {
+      "version": "2.38-3ubuntu1",
+      "arch": "amd64"
+    },
+    "bolt": {
+      "version": "0.9.2-1",
+      "arch": "amd64"
+    },
+    "bsdextrautils": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "bsdutils": {
+      "version": "1:2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "btrfs-progs": {
+      "version": "5.16.2-1",
+      "arch": "amd64"
+    },
+    "busybox-initramfs": {
+      "version": "1:1.30.1-7ubuntu3",
+      "arch": "amd64"
+    },
+    "busybox-static": {
+      "version": "1:1.30.1-7ubuntu3",
+      "arch": "amd64"
+    },
+    "byobu": {
+      "version": "5.133-1",
+      "arch": "all"
+    },
+    "bzip2": {
+      "version": "1.0.8-5build1",
+      "arch": "amd64"
+    },
+    "ca-certificates": {
+      "version": "20211016",
+      "arch": "all"
+    },
+    "chef": {
+      "version": "17.10.3-1",
+      "arch": "amd64"
+    },
+    "cloud-guest-utils": {
+      "version": "0.32-22-g45fe84a5-0ubuntu1",
+      "arch": "all"
+    },
+    "cloud-init": {
+      "version": "22.1-14-g2e17a0d6-0ubuntu1~22.04.5",
+      "arch": "all"
+    },
+    "cloud-initramfs-copymods": {
+      "version": "0.47ubuntu1",
+      "arch": "all"
+    },
+    "cloud-initramfs-dyn-netconf": {
+      "version": "0.47ubuntu1",
+      "arch": "all"
+    },
+    "console-setup": {
+      "version": "1.205ubuntu3",
+      "arch": "all"
+    },
+    "console-setup-linux": {
+      "version": "1.205ubuntu3",
+      "arch": "all"
+    },
+    "coreutils": {
+      "version": "8.32-4.1ubuntu1",
+      "arch": "amd64"
+    },
+    "cpio": {
+      "version": "2.13+dfsg-7",
+      "arch": "amd64"
+    },
+    "cron": {
+      "version": "3.0pl1-137ubuntu3",
+      "arch": "amd64"
+    },
+    "cryptsetup": {
+      "version": "2:2.4.3-1ubuntu1",
+      "arch": "amd64"
+    },
+    "cryptsetup-bin": {
+      "version": "2:2.4.3-1ubuntu1",
+      "arch": "amd64"
+    },
+    "cryptsetup-initramfs": {
+      "version": "2:2.4.3-1ubuntu1",
+      "arch": "all"
+    },
+    "curl": {
+      "version": "7.81.0-1ubuntu1.2",
+      "arch": "amd64"
+    },
+    "dash": {
+      "version": "0.5.11+git20210903+057cd650a4ed-3build1",
+      "arch": "amd64"
+    },
+    "dbus": {
+      "version": "1.12.20-2ubuntu4",
+      "arch": "amd64"
+    },
+    "dbus-user-session": {
+      "version": "1.12.20-2ubuntu4",
+      "arch": "amd64"
+    },
+    "dctrl-tools": {
+      "version": "2.24-3build2",
+      "arch": "amd64"
+    },
+    "debconf": {
+      "version": "1.5.79ubuntu1",
+      "arch": "all"
+    },
+    "debconf-i18n": {
+      "version": "1.5.79ubuntu1",
+      "arch": "all"
+    },
+    "debianutils": {
+      "version": "5.5-1ubuntu2",
+      "arch": "amd64"
+    },
+    "diffutils": {
+      "version": "1:3.8-0ubuntu2",
+      "arch": "amd64"
+    },
+    "dirmngr": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "distro-info": {
+      "version": "1.1build1",
+      "arch": "amd64"
+    },
+    "distro-info-data": {
+      "version": "0.52ubuntu0.1",
+      "arch": "all"
+    },
+    "dkms": {
+      "version": "2.8.7-2ubuntu2",
+      "arch": "all"
+    },
+    "dmeventd": {
+      "version": "2:1.02.175-2.1ubuntu4",
+      "arch": "amd64"
+    },
+    "dmidecode": {
+      "version": "3.3-3",
+      "arch": "amd64"
+    },
+    "dmsetup": {
+      "version": "2:1.02.175-2.1ubuntu4",
+      "arch": "amd64"
+    },
+    "dosfstools": {
+      "version": "4.2-1build3",
+      "arch": "amd64"
+    },
+    "dpkg": {
+      "version": "1.21.1ubuntu2",
+      "arch": "amd64"
+    },
+    "e2fsprogs": {
+      "version": "1.46.5-2ubuntu1",
+      "arch": "amd64"
+    },
+    "eatmydata": {
+      "version": "130-2build1",
+      "arch": "all"
+    },
+    "ed": {
+      "version": "1.18-1",
+      "arch": "amd64"
+    },
+    "eject": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "ethtool": {
+      "version": "1:5.16-1",
+      "arch": "amd64"
+    },
+    "fdisk": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "file": {
+      "version": "1:5.41-3",
+      "arch": "amd64"
+    },
+    "finalrd": {
+      "version": "9build1",
+      "arch": "all"
+    },
+    "findutils": {
+      "version": "4.8.0-1ubuntu3",
+      "arch": "amd64"
+    },
+    "firmware-sof-signed": {
+      "version": "2.0-1ubuntu3",
+      "arch": "all"
+    },
+    "fontconfig-config": {
+      "version": "2.13.1-4.2ubuntu5",
+      "arch": "all"
+    },
+    "fonts-dejavu-core": {
+      "version": "2.37-2build1",
+      "arch": "all"
+    },
+    "ftp": {
+      "version": "20210827-4build1",
+      "arch": "all"
+    },
+    "fuse3": {
+      "version": "3.10.5-1build1",
+      "arch": "amd64"
+    },
+    "fwupd": {
+      "version": "1.7.5-3",
+      "arch": "amd64"
+    },
+    "fwupd-signed": {
+      "version": "1.44+1.2-3",
+      "arch": "amd64"
+    },
+    "gawk": {
+      "version": "1:5.1.0-1build3",
+      "arch": "amd64"
+    },
+    "gcc-12-base": {
+      "version": "12-20220319-1ubuntu1",
+      "arch": "amd64"
+    },
+    "gdisk": {
+      "version": "1.0.8-4build1",
+      "arch": "amd64"
+    },
+    "gettext-base": {
+      "version": "0.21-4ubuntu4",
+      "arch": "amd64"
+    },
+    "gir1.2-glib-2.0": {
+      "version": "1.72.0-1",
+      "arch": "amd64"
+    },
+    "gir1.2-packagekitglib-1.0": {
+      "version": "1.2.5-2ubuntu2",
+      "arch": "amd64"
+    },
+    "git": {
+      "version": "1:2.34.1-1ubuntu1.2",
+      "arch": "amd64"
+    },
+    "git-man": {
+      "version": "1:2.34.1-1ubuntu1.2",
+      "arch": "all"
+    },
+    "gnupg": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "all"
+    },
+    "gnupg-l10n": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "all"
+    },
+    "gnupg-utils": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "gpg": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "gpg-agent": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "gpg-wks-client": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "gpg-wks-server": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "gpgconf": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "gpgsm": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "gpgv": {
+      "version": "2.2.27-3ubuntu2",
+      "arch": "amd64"
+    },
+    "grep": {
+      "version": "3.7-1build1",
+      "arch": "amd64"
+    },
+    "groff-base": {
+      "version": "1.22.4-8build1",
+      "arch": "amd64"
+    },
+    "grub-common": {
+      "version": "2.06-2ubuntu7",
+      "arch": "amd64"
+    },
+    "grub-gfxpayload-lists": {
+      "version": "0.7",
+      "arch": "amd64"
+    },
+    "grub-pc": {
+      "version": "2.06-2ubuntu7",
+      "arch": "amd64"
+    },
+    "grub-pc-bin": {
+      "version": "2.06-2ubuntu7",
+      "arch": "amd64"
+    },
+    "grub2-common": {
+      "version": "2.06-2ubuntu7",
+      "arch": "amd64"
+    },
+    "gzip": {
+      "version": "1.10-4ubuntu4",
+      "arch": "amd64"
+    },
+    "hdparm": {
+      "version": "9.60+ds-1build3",
+      "arch": "amd64"
+    },
+    "hostname": {
+      "version": "3.23ubuntu2",
+      "arch": "amd64"
+    },
+    "htop": {
+      "version": "3.0.5-7build2",
+      "arch": "amd64"
+    },
+    "info": {
+      "version": "6.8-4build1",
+      "arch": "amd64"
+    },
+    "init": {
+      "version": "1.62",
+      "arch": "amd64"
+    },
+    "init-system-helpers": {
+      "version": "1.62",
+      "arch": "all"
+    },
+    "initramfs-tools": {
+      "version": "0.140ubuntu13",
+      "arch": "all"
+    },
+    "initramfs-tools-bin": {
+      "version": "0.140ubuntu13",
+      "arch": "amd64"
+    },
+    "initramfs-tools-core": {
+      "version": "0.140ubuntu13",
+      "arch": "all"
+    },
+    "install-info": {
+      "version": "6.8-4build1",
+      "arch": "amd64"
+    },
+    "intel-microcode": {
+      "version": "3.20210608.2ubuntu1",
+      "arch": "amd64"
+    },
+    "iproute2": {
+      "version": "5.15.0-1ubuntu2",
+      "arch": "amd64"
+    },
+    "iptables": {
+      "version": "1.8.7-1ubuntu5",
+      "arch": "amd64"
+    },
+    "iputils-ping": {
+      "version": "3:20211215-1",
+      "arch": "amd64"
+    },
+    "iputils-tracepath": {
+      "version": "3:20211215-1",
+      "arch": "amd64"
+    },
+    "irqbalance": {
+      "version": "1.8.0-1build1",
+      "arch": "amd64"
+    },
+    "isc-dhcp-client": {
+      "version": "4.4.1-2.3ubuntu2",
+      "arch": "amd64"
+    },
+    "isc-dhcp-common": {
+      "version": "4.4.1-2.3ubuntu2",
+      "arch": "amd64"
+    },
+    "iso-codes": {
+      "version": "4.9.0-1",
+      "arch": "all"
+    },
+    "iucode-tool": {
+      "version": "2.3.1-1build1",
+      "arch": "amd64"
+    },
+    "kbd": {
+      "version": "2.3.0-3ubuntu4",
+      "arch": "amd64"
+    },
+    "keyboard-configuration": {
+      "version": "1.205ubuntu3",
+      "arch": "all"
+    },
+    "klibc-utils": {
+      "version": "2.0.10-4",
+      "arch": "amd64"
+    },
+    "kmod": {
+      "version": "29-1ubuntu1",
+      "arch": "amd64"
+    },
+    "kpartx": {
+      "version": "0.8.8-1ubuntu1",
+      "arch": "amd64"
+    },
+    "landscape-common": {
+      "version": "19.12-0ubuntu13",
+      "arch": "amd64"
+    },
+    "less": {
+      "version": "590-1build1",
+      "arch": "amd64"
+    },
+    "libacl1": {
+      "version": "2.3.1-1",
+      "arch": "amd64"
+    },
+    "libaio1": {
+      "version": "0.3.112-13build1",
+      "arch": "amd64"
+    },
+    "libapparmor1": {
+      "version": "3.0.4-2ubuntu2",
+      "arch": "amd64"
+    },
+    "libappstream4": {
+      "version": "0.15.2-2",
+      "arch": "amd64"
+    },
+    "libapt-pkg6.0": {
+      "version": "2.4.5",
+      "arch": "amd64"
+    },
+    "libarchive13": {
+      "version": "3.6.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libargon2-1": {
+      "version": "0~20171227-0.3",
+      "arch": "amd64"
+    },
+    "libassuan0": {
+      "version": "2.5.5-1build1",
+      "arch": "amd64"
+    },
+    "libatasmart4": {
+      "version": "0.19-5build2",
+      "arch": "amd64"
+    },
+    "libatm1": {
+      "version": "1:2.5.1-4build2",
+      "arch": "amd64"
+    },
+    "libattr1": {
+      "version": "1:2.5.1-1build1",
+      "arch": "amd64"
+    },
+    "libaudit-common": {
+      "version": "1:3.0.7-1build1",
+      "arch": "all"
+    },
+    "libaudit1": {
+      "version": "1:3.0.7-1build1",
+      "arch": "amd64"
+    },
+    "libbinutils": {
+      "version": "2.38-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libblkid1": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "libblockdev-crypto2": {
+      "version": "2.26-1",
+      "arch": "amd64"
+    },
+    "libblockdev-fs2": {
+      "version": "2.26-1",
+      "arch": "amd64"
+    },
+    "libblockdev-loop2": {
+      "version": "2.26-1",
+      "arch": "amd64"
+    },
+    "libblockdev-part-err2": {
+      "version": "2.26-1",
+      "arch": "amd64"
+    },
+    "libblockdev-part2": {
+      "version": "2.26-1",
+      "arch": "amd64"
+    },
+    "libblockdev-swap2": {
+      "version": "2.26-1",
+      "arch": "amd64"
+    },
+    "libblockdev-utils2": {
+      "version": "2.26-1",
+      "arch": "amd64"
+    },
+    "libblockdev2": {
+      "version": "2.26-1",
+      "arch": "amd64"
+    },
+    "libbpf0": {
+      "version": "1:0.5.0-1",
+      "arch": "amd64"
+    },
+    "libbrotli1": {
+      "version": "1.0.9-2build6",
+      "arch": "amd64"
+    },
+    "libbsd0": {
+      "version": "0.11.5-1",
+      "arch": "amd64"
+    },
+    "libbz2-1.0": {
+      "version": "1.0.8-5build1",
+      "arch": "amd64"
+    },
+    "libc-bin": {
+      "version": "2.35-0ubuntu3",
+      "arch": "amd64"
+    },
+    "libc6": {
+      "version": "2.35-0ubuntu3",
+      "arch": "amd64"
+    },
+    "libcap-ng0": {
+      "version": "0.7.9-2.2build3",
+      "arch": "amd64"
+    },
+    "libcap2": {
+      "version": "1:2.44-1build3",
+      "arch": "amd64"
+    },
+    "libcap2-bin": {
+      "version": "1:2.44-1build3",
+      "arch": "amd64"
+    },
+    "libcbor0.8": {
+      "version": "0.8.0-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libcom-err2": {
+      "version": "1.46.5-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libcrypt1": {
+      "version": "1:4.4.27-1",
+      "arch": "amd64"
+    },
+    "libcryptsetup12": {
+      "version": "2:2.4.3-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libctf-nobfd0": {
+      "version": "2.38-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libctf0": {
+      "version": "2.38-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libcurl3-gnutls": {
+      "version": "7.81.0-1ubuntu1.2",
+      "arch": "amd64"
+    },
+    "libcurl4": {
+      "version": "7.81.0-1ubuntu1.2",
+      "arch": "amd64"
+    },
+    "libdb5.3": {
+      "version": "5.3.28+dfsg1-0.8ubuntu3",
+      "arch": "amd64"
+    },
+    "libdbus-1-3": {
+      "version": "1.12.20-2ubuntu4",
+      "arch": "amd64"
+    },
+    "libdbus-glib-1-2": {
+      "version": "0.112-2build1",
+      "arch": "amd64"
+    },
+    "libdebconfclient0": {
+      "version": "0.261ubuntu1",
+      "arch": "amd64"
+    },
+    "libdevmapper-event1.02.1": {
+      "version": "2:1.02.175-2.1ubuntu4",
+      "arch": "amd64"
+    },
+    "libdevmapper1.02.1": {
+      "version": "2:1.02.175-2.1ubuntu4",
+      "arch": "amd64"
+    },
+    "libdns-export1110": {
+      "version": "1:9.11.19+dfsg-2.1ubuntu3",
+      "arch": "amd64"
+    },
+    "libdrm-common": {
+      "version": "2.4.110-1ubuntu1",
+      "arch": "all"
+    },
+    "libdrm2": {
+      "version": "2.4.110-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libdw1": {
+      "version": "0.186-1build1",
+      "arch": "amd64"
+    },
+    "libeatmydata1": {
+      "version": "130-2build1",
+      "arch": "amd64"
+    },
+    "libedit2": {
+      "version": "3.1-20210910-1build1",
+      "arch": "amd64"
+    },
+    "libefiboot1": {
+      "version": "37-6ubuntu2",
+      "arch": "amd64"
+    },
+    "libefivar1": {
+      "version": "37-6ubuntu2",
+      "arch": "amd64"
+    },
+    "libelf1": {
+      "version": "0.186-1build1",
+      "arch": "amd64"
+    },
+    "liberror-perl": {
+      "version": "0.17029-1",
+      "arch": "all"
+    },
+    "libestr0": {
+      "version": "0.1.10-2.1build3",
+      "arch": "amd64"
+    },
+    "libevdev2": {
+      "version": "1.12.1+dfsg-1",
+      "arch": "amd64"
+    },
+    "libevent-core-2.1-7": {
+      "version": "2.1.12-stable-1build3",
+      "arch": "amd64"
+    },
+    "libexpat1": {
+      "version": "2.4.7-1",
+      "arch": "amd64"
+    },
+    "libext2fs2": {
+      "version": "1.46.5-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libfakeroot": {
+      "version": "1.28-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libfastjson4": {
+      "version": "0.99.9-1build2",
+      "arch": "amd64"
+    },
+    "libfdisk1": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "libffi8": {
+      "version": "3.4.2-4",
+      "arch": "amd64"
+    },
+    "libfido2-1": {
+      "version": "1.10.0-1",
+      "arch": "amd64"
+    },
+    "libflashrom1": {
+      "version": "1.2-5build1",
+      "arch": "amd64"
+    },
+    "libfreetype6": {
+      "version": "2.11.1+dfsg-1build1",
+      "arch": "amd64"
+    },
+    "libfribidi0": {
+      "version": "1.0.8-2ubuntu3.1",
+      "arch": "amd64"
+    },
+    "libftdi1-2": {
+      "version": "1.5-5build3",
+      "arch": "amd64"
+    },
+    "libfuse3-3": {
+      "version": "3.10.5-1build1",
+      "arch": "amd64"
+    },
+    "libfwupd2": {
+      "version": "1.7.5-3",
+      "arch": "amd64"
+    },
+    "libfwupdplugin5": {
+      "version": "1.7.5-3",
+      "arch": "amd64"
+    },
+    "libgcab-1.0-0": {
+      "version": "1.4-3build2",
+      "arch": "amd64"
+    },
+    "libgcc-s1": {
+      "version": "12-20220319-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libgcrypt20": {
+      "version": "1.9.4-3ubuntu3",
+      "arch": "amd64"
+    },
+    "libgdbm-compat4": {
+      "version": "1.23-1",
+      "arch": "amd64"
+    },
+    "libgdbm6": {
+      "version": "1.23-1",
+      "arch": "amd64"
+    },
+    "libgirepository-1.0-1": {
+      "version": "1.72.0-1",
+      "arch": "amd64"
+    },
+    "libglib2.0-0": {
+      "version": "2.72.1-1",
+      "arch": "amd64"
+    },
+    "libglib2.0-bin": {
+      "version": "2.72.1-1",
+      "arch": "amd64"
+    },
+    "libglib2.0-data": {
+      "version": "2.72.1-1",
+      "arch": "all"
+    },
+    "libgmp10": {
+      "version": "2:6.2.1+dfsg-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libgnutls30": {
+      "version": "3.7.3-4ubuntu1",
+      "arch": "amd64"
+    },
+    "libgpg-error0": {
+      "version": "1.43-3",
+      "arch": "amd64"
+    },
+    "libgpgme11": {
+      "version": "1.16.0-1.2ubuntu4",
+      "arch": "amd64"
+    },
+    "libgpm2": {
+      "version": "1.20.7-10build1",
+      "arch": "amd64"
+    },
+    "libgssapi-krb5-2": {
+      "version": "1.19.2-2",
+      "arch": "amd64"
+    },
+    "libgstreamer1.0-0": {
+      "version": "1.20.1-1",
+      "arch": "amd64"
+    },
+    "libgudev-1.0-0": {
+      "version": "1:237-2build1",
+      "arch": "amd64"
+    },
+    "libgusb2": {
+      "version": "0.3.10-1",
+      "arch": "amd64"
+    },
+    "libhogweed6": {
+      "version": "3.7.3-1build2",
+      "arch": "amd64"
+    },
+    "libicu70": {
+      "version": "70.1-2",
+      "arch": "amd64"
+    },
+    "libidn2-0": {
+      "version": "2.3.2-2build1",
+      "arch": "amd64"
+    },
+    "libimobiledevice6": {
+      "version": "1.3.0-6build3",
+      "arch": "amd64"
+    },
+    "libinih1": {
+      "version": "53-1ubuntu3",
+      "arch": "amd64"
+    },
+    "libintl-perl": {
+      "version": "1.26-3build2",
+      "arch": "all"
+    },
+    "libintl-xs-perl": {
+      "version": "1.26-3build2",
+      "arch": "amd64"
+    },
+    "libip4tc2": {
+      "version": "1.8.7-1ubuntu5",
+      "arch": "amd64"
+    },
+    "libip6tc2": {
+      "version": "1.8.7-1ubuntu5",
+      "arch": "amd64"
+    },
+    "libisc-export1105": {
+      "version": "1:9.11.19+dfsg-2.1ubuntu3",
+      "arch": "amd64"
+    },
+    "libisns0": {
+      "version": "0.101-0ubuntu2",
+      "arch": "amd64"
+    },
+    "libjansson4": {
+      "version": "2.13.1-1.1build3",
+      "arch": "amd64"
+    },
+    "libjcat1": {
+      "version": "0.1.9-1",
+      "arch": "amd64"
+    },
+    "libjson-c5": {
+      "version": "0.15-2build4",
+      "arch": "amd64"
+    },
+    "libjson-glib-1.0-0": {
+      "version": "1.6.6-1build1",
+      "arch": "amd64"
+    },
+    "libjson-glib-1.0-common": {
+      "version": "1.6.6-1build1",
+      "arch": "all"
+    },
+    "libk5crypto3": {
+      "version": "1.19.2-2",
+      "arch": "amd64"
+    },
+    "libkeyutils1": {
+      "version": "1.6.1-2ubuntu3",
+      "arch": "amd64"
+    },
+    "libklibc": {
+      "version": "2.0.10-4",
+      "arch": "amd64"
+    },
+    "libkmod2": {
+      "version": "29-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libkrb5-3": {
+      "version": "1.19.2-2",
+      "arch": "amd64"
+    },
+    "libkrb5support0": {
+      "version": "1.19.2-2",
+      "arch": "amd64"
+    },
+    "libksba8": {
+      "version": "1.6.0-2build1",
+      "arch": "amd64"
+    },
+    "libldap-2.5-0": {
+      "version": "2.5.11+dfsg-1~exp1ubuntu3.1",
+      "arch": "amd64"
+    },
+    "libldap-common": {
+      "version": "2.5.11+dfsg-1~exp1ubuntu3.1",
+      "arch": "all"
+    },
+    "liblmdb0": {
+      "version": "0.9.24-1build2",
+      "arch": "amd64"
+    },
+    "liblocale-gettext-perl": {
+      "version": "1.07-4build3",
+      "arch": "amd64"
+    },
+    "liblvm2cmd2.03": {
+      "version": "2.03.11-2.1ubuntu4",
+      "arch": "amd64"
+    },
+    "liblz4-1": {
+      "version": "1.9.3-2build2",
+      "arch": "amd64"
+    },
+    "liblzma5": {
+      "version": "5.2.5-2ubuntu1",
+      "arch": "amd64"
+    },
+    "liblzo2-2": {
+      "version": "2.10-2build3",
+      "arch": "amd64"
+    },
+    "libmagic-mgc": {
+      "version": "1:5.41-3",
+      "arch": "amd64"
+    },
+    "libmagic1": {
+      "version": "1:5.41-3",
+      "arch": "amd64"
+    },
+    "libmaxminddb0": {
+      "version": "1.5.2-1build2",
+      "arch": "amd64"
+    },
+    "libmbim-glib4": {
+      "version": "1.26.2-1build1",
+      "arch": "amd64"
+    },
+    "libmbim-proxy": {
+      "version": "1.26.2-1build1",
+      "arch": "amd64"
+    },
+    "libmd0": {
+      "version": "1.0.4-1build1",
+      "arch": "amd64"
+    },
+    "libmm-glib0": {
+      "version": "1.18.6-1",
+      "arch": "amd64"
+    },
+    "libmnl0": {
+      "version": "1.0.4-3build2",
+      "arch": "amd64"
+    },
+    "libmodule-find-perl": {
+      "version": "0.15-1",
+      "arch": "all"
+    },
+    "libmodule-scandeps-perl": {
+      "version": "1.31-1",
+      "arch": "all"
+    },
+    "libmount1": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "libmpdec3": {
+      "version": "2.5.1-2build2",
+      "arch": "amd64"
+    },
+    "libmpfr6": {
+      "version": "4.1.0-3build3",
+      "arch": "amd64"
+    },
+    "libmspack0": {
+      "version": "0.10.1-2build2",
+      "arch": "amd64"
+    },
+    "libncurses6": {
+      "version": "6.3-2",
+      "arch": "amd64"
+    },
+    "libncursesw6": {
+      "version": "6.3-2",
+      "arch": "amd64"
+    },
+    "libnetfilter-conntrack3": {
+      "version": "1.0.9-1",
+      "arch": "amd64"
+    },
+    "libnetplan0": {
+      "version": "0.104-0ubuntu2",
+      "arch": "amd64"
+    },
+    "libnettle8": {
+      "version": "3.7.3-1build2",
+      "arch": "amd64"
+    },
+    "libnewt0.52": {
+      "version": "0.52.21-5ubuntu2",
+      "arch": "amd64"
+    },
+    "libnfnetlink0": {
+      "version": "1.0.1-3build3",
+      "arch": "amd64"
+    },
+    "libnftables1": {
+      "version": "1.0.2-1ubuntu2",
+      "arch": "amd64"
+    },
+    "libnftnl11": {
+      "version": "1.2.1-1build1",
+      "arch": "amd64"
+    },
+    "libnghttp2-14": {
+      "version": "1.43.0-1build3",
+      "arch": "amd64"
+    },
+    "libnl-3-200": {
+      "version": "3.5.0-0.1",
+      "arch": "amd64"
+    },
+    "libnl-genl-3-200": {
+      "version": "3.5.0-0.1",
+      "arch": "amd64"
+    },
+    "libnpth0": {
+      "version": "1.6-3build2",
+      "arch": "amd64"
+    },
+    "libnsl2": {
+      "version": "1.3.0-2build2",
+      "arch": "amd64"
+    },
+    "libnspr4": {
+      "version": "2:4.32-3build1",
+      "arch": "amd64"
+    },
+    "libnss-systemd": {
+      "version": "249.11-0ubuntu3.1",
+      "arch": "amd64"
+    },
+    "libnss3": {
+      "version": "2:3.68.2-0ubuntu1",
+      "arch": "amd64"
+    },
+    "libntfs-3g89": {
+      "version": "1:2021.8.22-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libnuma1": {
+      "version": "2.0.14-3ubuntu2",
+      "arch": "amd64"
+    },
+    "libopeniscsiusr": {
+      "version": "2.1.5-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libp11-kit0": {
+      "version": "0.24.0-6build1",
+      "arch": "amd64"
+    },
+    "libpackagekit-glib2-18": {
+      "version": "1.2.5-2ubuntu2",
+      "arch": "amd64"
+    },
+    "libpam-cap": {
+      "version": "1:2.44-1build3",
+      "arch": "amd64"
+    },
+    "libpam-modules": {
+      "version": "1.4.0-11ubuntu2",
+      "arch": "amd64"
+    },
+    "libpam-modules-bin": {
+      "version": "1.4.0-11ubuntu2",
+      "arch": "amd64"
+    },
+    "libpam-runtime": {
+      "version": "1.4.0-11ubuntu2",
+      "arch": "all"
+    },
+    "libpam-systemd": {
+      "version": "249.11-0ubuntu3.1",
+      "arch": "amd64"
+    },
+    "libpam0g": {
+      "version": "1.4.0-11ubuntu2",
+      "arch": "amd64"
+    },
+    "libparted-fs-resize0": {
+      "version": "3.4-2build1",
+      "arch": "amd64"
+    },
+    "libparted2": {
+      "version": "3.4-2build1",
+      "arch": "amd64"
+    },
+    "libpcap0.8": {
+      "version": "1.10.1-4build1",
+      "arch": "amd64"
+    },
+    "libpci3": {
+      "version": "1:3.7.0-6",
+      "arch": "amd64"
+    },
+    "libpcre2-8-0": {
+      "version": "10.39-3build1",
+      "arch": "amd64"
+    },
+    "libpcre3": {
+      "version": "2:8.39-13ubuntu0.22.04.1",
+      "arch": "amd64"
+    },
+    "libperl5.34": {
+      "version": "5.34.0-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libpipeline1": {
+      "version": "1.5.5-1",
+      "arch": "amd64"
+    },
+    "libplist3": {
+      "version": "2.2.0-6build2",
+      "arch": "amd64"
+    },
+    "libplymouth5": {
+      "version": "0.9.5+git20211018-1ubuntu3",
+      "arch": "amd64"
+    },
+    "libpng16-16": {
+      "version": "1.6.37-3build5",
+      "arch": "amd64"
+    },
+    "libpolkit-agent-1-0": {
+      "version": "0.105-33",
+      "arch": "amd64"
+    },
+    "libpolkit-gobject-1-0": {
+      "version": "0.105-33",
+      "arch": "amd64"
+    },
+    "libpopt0": {
+      "version": "1.18-3build1",
+      "arch": "amd64"
+    },
+    "libproc-processtable-perl": {
+      "version": "0.634-1build1",
+      "arch": "amd64"
+    },
+    "libprocps8": {
+      "version": "2:3.3.17-6ubuntu2",
+      "arch": "amd64"
+    },
+    "libpsl5": {
+      "version": "0.21.0-1.2build2",
+      "arch": "amd64"
+    },
+    "libpython3-stdlib": {
+      "version": "3.10.4-0ubuntu2",
+      "arch": "amd64"
+    },
+    "libpython3.10": {
+      "version": "3.10.4-3",
+      "arch": "amd64"
+    },
+    "libpython3.10-minimal": {
+      "version": "3.10.4-3",
+      "arch": "amd64"
+    },
+    "libpython3.10-stdlib": {
+      "version": "3.10.4-3",
+      "arch": "amd64"
+    },
+    "libqmi-glib5": {
+      "version": "1.30.4-1",
+      "arch": "amd64"
+    },
+    "libqmi-proxy": {
+      "version": "1.30.4-1",
+      "arch": "amd64"
+    },
+    "libreadline8": {
+      "version": "8.1.2-1",
+      "arch": "amd64"
+    },
+    "librtmp1": {
+      "version": "2.4+20151223.gitfa8646d.1-2build4",
+      "arch": "amd64"
+    },
+    "libsasl2-2": {
+      "version": "2.1.27+dfsg2-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libsasl2-modules": {
+      "version": "2.1.27+dfsg2-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libsasl2-modules-db": {
+      "version": "2.1.27+dfsg2-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libseccomp2": {
+      "version": "2.5.3-2ubuntu2",
+      "arch": "amd64"
+    },
+    "libselinux1": {
+      "version": "3.3-1build2",
+      "arch": "amd64"
+    },
+    "libsemanage-common": {
+      "version": "3.3-1build2",
+      "arch": "all"
+    },
+    "libsemanage2": {
+      "version": "3.3-1build2",
+      "arch": "amd64"
+    },
+    "libsepol2": {
+      "version": "3.3-1build1",
+      "arch": "amd64"
+    },
+    "libsgutils2-2": {
+      "version": "1.46-1build1",
+      "arch": "amd64"
+    },
+    "libsigsegv2": {
+      "version": "2.13-1ubuntu3",
+      "arch": "amd64"
+    },
+    "libslang2": {
+      "version": "2.3.2-5build4",
+      "arch": "amd64"
+    },
+    "libsmartcols1": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "libsmbios-c2": {
+      "version": "2.4.3-1build1",
+      "arch": "amd64"
+    },
+    "libsodium23": {
+      "version": "1.0.18-1build2",
+      "arch": "amd64"
+    },
+    "libsort-naturally-perl": {
+      "version": "1.03-2",
+      "arch": "all"
+    },
+    "libsqlite3-0": {
+      "version": "3.37.2-2",
+      "arch": "amd64"
+    },
+    "libss2": {
+      "version": "1.46.5-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libssh-4": {
+      "version": "0.9.6-2build1",
+      "arch": "amd64"
+    },
+    "libssl3": {
+      "version": "3.0.2-0ubuntu1.2",
+      "arch": "amd64"
+    },
+    "libstdc++6": {
+      "version": "12-20220319-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libstemmer0d": {
+      "version": "2.2.0-1build1",
+      "arch": "amd64"
+    },
+    "libsystemd0": {
+      "version": "249.11-0ubuntu3.1",
+      "arch": "amd64"
+    },
+    "libtasn1-6": {
+      "version": "4.18.0-4build1",
+      "arch": "amd64"
+    },
+    "libtcl8.6": {
+      "version": "8.6.12+dfsg-1build1",
+      "arch": "amd64"
+    },
+    "libterm-readkey-perl": {
+      "version": "2.38-1build4",
+      "arch": "amd64"
+    },
+    "libtext-charwidth-perl": {
+      "version": "0.04-10build3",
+      "arch": "amd64"
+    },
+    "libtext-iconv-perl": {
+      "version": "1.7-7build3",
+      "arch": "amd64"
+    },
+    "libtext-wrapi18n-perl": {
+      "version": "0.06-9",
+      "arch": "all"
+    },
+    "libtinfo6": {
+      "version": "6.3-2",
+      "arch": "amd64"
+    },
+    "libtirpc-common": {
+      "version": "1.3.2-2build1",
+      "arch": "all"
+    },
+    "libtirpc3": {
+      "version": "1.3.2-2build1",
+      "arch": "amd64"
+    },
+    "libtss2-esys-3.0.2-0": {
+      "version": "3.2.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-mu0": {
+      "version": "3.2.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-sys1": {
+      "version": "3.2.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-tcti-cmd0": {
+      "version": "3.2.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-tcti-device0": {
+      "version": "3.2.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-tcti-mssim0": {
+      "version": "3.2.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-tcti-swtpm0": {
+      "version": "3.2.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libuchardet0": {
+      "version": "0.0.7-1build2",
+      "arch": "amd64"
+    },
+    "libudev1": {
+      "version": "249.11-0ubuntu3.1",
+      "arch": "amd64"
+    },
+    "libudisks2-0": {
+      "version": "2.9.4-1ubuntu2",
+      "arch": "amd64"
+    },
+    "libunistring2": {
+      "version": "1.0-1",
+      "arch": "amd64"
+    },
+    "libunwind8": {
+      "version": "1.3.2-2build2",
+      "arch": "amd64"
+    },
+    "libupower-glib3": {
+      "version": "0.99.17-1",
+      "arch": "amd64"
+    },
+    "liburcu8": {
+      "version": "0.13.1-1",
+      "arch": "amd64"
+    },
+    "libusb-1.0-0": {
+      "version": "2:1.0.25-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libusbmuxd6": {
+      "version": "2.0.2-3build2",
+      "arch": "amd64"
+    },
+    "libutempter0": {
+      "version": "1.2.1-2build2",
+      "arch": "amd64"
+    },
+    "libuuid1": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "libuv1": {
+      "version": "1.43.0-1",
+      "arch": "amd64"
+    },
+    "libvolume-key1": {
+      "version": "0.3.12-3.1build3",
+      "arch": "amd64"
+    },
+    "libwrap0": {
+      "version": "7.6.q-31build2",
+      "arch": "amd64"
+    },
+    "libxml2": {
+      "version": "2.9.13+dfsg-1ubuntu0.1",
+      "arch": "amd64"
+    },
+    "libxmlb2": {
+      "version": "0.3.6-2build1",
+      "arch": "amd64"
+    },
+    "libxmlsec1": {
+      "version": "1.2.33-1build2",
+      "arch": "amd64"
+    },
+    "libxmlsec1-openssl": {
+      "version": "1.2.33-1build2",
+      "arch": "amd64"
+    },
+    "libxslt1.1": {
+      "version": "1.1.34-4build2",
+      "arch": "amd64"
+    },
+    "libxtables12": {
+      "version": "1.8.7-1ubuntu5",
+      "arch": "amd64"
+    },
+    "libxxhash0": {
+      "version": "0.8.1-1",
+      "arch": "amd64"
+    },
+    "libyaml-0-2": {
+      "version": "0.2.2-1build2",
+      "arch": "amd64"
+    },
+    "libzstd1": {
+      "version": "1.4.8+dfsg-3build1",
+      "arch": "amd64"
+    },
+    "linux-base": {
+      "version": "4.5ubuntu9",
+      "arch": "all"
+    },
+    "linux-firmware": {
+      "version": "20220329.git681281e4-0ubuntu3",
+      "arch": "all"
+    },
+    "linux-image-5.15.0-30-generic": {
+      "version": "5.15.0-30.31",
+      "arch": "amd64"
+    },
+    "linux-image-generic": {
+      "version": "5.15.0.30.33",
+      "arch": "amd64"
+    },
+    "linux-modules-5.15.0-30-generic": {
+      "version": "5.15.0-30.31",
+      "arch": "amd64"
+    },
+    "linux-modules-extra-5.15.0-30-generic": {
+      "version": "5.15.0-30.31",
+      "arch": "amd64"
+    },
+    "locales": {
+      "version": "2.35-0ubuntu3",
+      "arch": "all"
+    },
+    "login": {
+      "version": "1:4.8.1-2ubuntu2",
+      "arch": "amd64"
+    },
+    "logrotate": {
+      "version": "3.19.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "logsave": {
+      "version": "1.46.5-2ubuntu1",
+      "arch": "amd64"
+    },
+    "lsb-base": {
+      "version": "11.1.0ubuntu4",
+      "arch": "all"
+    },
+    "lsb-release": {
+      "version": "11.1.0ubuntu4",
+      "arch": "all"
+    },
+    "lshw": {
+      "version": "02.19.git.2021.06.19.996aaad9c7-2build1",
+      "arch": "amd64"
+    },
+    "lsof": {
+      "version": "4.93.2+dfsg-1.1build2",
+      "arch": "amd64"
+    },
+    "lvm2": {
+      "version": "2.03.11-2.1ubuntu4",
+      "arch": "amd64"
+    },
+    "lxd-agent-loader": {
+      "version": "0.5",
+      "arch": "all"
+    },
+    "man-db": {
+      "version": "2.10.2-1",
+      "arch": "amd64"
+    },
+    "manpages": {
+      "version": "5.10-1ubuntu1",
+      "arch": "all"
+    },
+    "mawk": {
+      "version": "1.3.4.20200120-3",
+      "arch": "amd64"
+    },
+    "mdadm": {
+      "version": "4.2-0ubuntu1",
+      "arch": "amd64"
+    },
+    "media-types": {
+      "version": "7.0.0",
+      "arch": "all"
+    },
+    "modemmanager": {
+      "version": "1.18.6-1",
+      "arch": "amd64"
+    },
+    "mount": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "mtr-tiny": {
+      "version": "0.95-1",
+      "arch": "amd64"
+    },
+    "multipath-tools": {
+      "version": "0.8.8-1ubuntu1",
+      "arch": "amd64"
+    },
+    "nano": {
+      "version": "6.2-1",
+      "arch": "amd64"
+    },
+    "ncurses-base": {
+      "version": "6.3-2",
+      "arch": "all"
+    },
+    "ncurses-bin": {
+      "version": "6.3-2",
+      "arch": "amd64"
+    },
+    "ncurses-term": {
+      "version": "6.3-2",
+      "arch": "all"
+    },
+    "needrestart": {
+      "version": "3.5-5ubuntu2.1",
+      "arch": "all"
+    },
+    "netbase": {
+      "version": "6.3",
+      "arch": "all"
+    },
+    "netcat-openbsd": {
+      "version": "1.218-4ubuntu1",
+      "arch": "amd64"
+    },
+    "netplan.io": {
+      "version": "0.104-0ubuntu2",
+      "arch": "amd64"
+    },
+    "networkd-dispatcher": {
+      "version": "2.1-2ubuntu0.22.04.2",
+      "arch": "all"
+    },
+    "nftables": {
+      "version": "1.0.2-1ubuntu2",
+      "arch": "amd64"
+    },
+    "ntfs-3g": {
+      "version": "1:2021.8.22-3ubuntu1",
+      "arch": "amd64"
+    },
+    "open-iscsi": {
+      "version": "2.1.5-1ubuntu1",
+      "arch": "amd64"
+    },
+    "open-vm-tools": {
+      "version": "2:11.3.5-1ubuntu4",
+      "arch": "amd64"
+    },
+    "openssh-client": {
+      "version": "1:8.9p1-3",
+      "arch": "amd64"
+    },
+    "openssh-server": {
+      "version": "1:8.9p1-3",
+      "arch": "amd64"
+    },
+    "openssh-sftp-server": {
+      "version": "1:8.9p1-3",
+      "arch": "amd64"
+    },
+    "openssl": {
+      "version": "3.0.2-0ubuntu1.2",
+      "arch": "amd64"
+    },
+    "os-prober": {
+      "version": "1.79ubuntu2",
+      "arch": "amd64"
+    },
+    "overlayroot": {
+      "version": "0.47ubuntu1",
+      "arch": "all"
+    },
+    "packagekit": {
+      "version": "1.2.5-2ubuntu2",
+      "arch": "amd64"
+    },
+    "packagekit-tools": {
+      "version": "1.2.5-2ubuntu2",
+      "arch": "amd64"
+    },
+    "parted": {
+      "version": "3.4-2build1",
+      "arch": "amd64"
+    },
+    "passwd": {
+      "version": "1:4.8.1-2ubuntu2",
+      "arch": "amd64"
+    },
+    "pastebinit": {
+      "version": "1.5.1-1ubuntu1",
+      "arch": "all"
+    },
+    "patch": {
+      "version": "2.7.6-7build2",
+      "arch": "amd64"
+    },
+    "pci.ids": {
+      "version": "0.0~2022.01.22-1",
+      "arch": "all"
+    },
+    "pciutils": {
+      "version": "1:3.7.0-6",
+      "arch": "amd64"
+    },
+    "perl": {
+      "version": "5.34.0-3ubuntu1",
+      "arch": "amd64"
+    },
+    "perl-base": {
+      "version": "5.34.0-3ubuntu1",
+      "arch": "amd64"
+    },
+    "perl-modules-5.34": {
+      "version": "5.34.0-3ubuntu1",
+      "arch": "all"
+    },
+    "pinentry-curses": {
+      "version": "1.1.1-1build2",
+      "arch": "amd64"
+    },
+    "pkexec": {
+      "version": "0.105-33",
+      "arch": "amd64"
+    },
+    "plymouth": {
+      "version": "0.9.5+git20211018-1ubuntu3",
+      "arch": "amd64"
+    },
+    "plymouth-theme-ubuntu-text": {
+      "version": "0.9.5+git20211018-1ubuntu3",
+      "arch": "amd64"
+    },
+    "policykit-1": {
+      "version": "0.105-33",
+      "arch": "amd64"
+    },
+    "polkitd": {
+      "version": "0.105-33",
+      "arch": "amd64"
+    },
+    "pollinate": {
+      "version": "4.33-3ubuntu2",
+      "arch": "all"
+    },
+    "powermgmt-base": {
+      "version": "1.36",
+      "arch": "all"
+    },
+    "procps": {
+      "version": "2:3.3.17-6ubuntu2",
+      "arch": "amd64"
+    },
+    "psmisc": {
+      "version": "23.4-2build3",
+      "arch": "amd64"
+    },
+    "publicsuffix": {
+      "version": "20211207.1025-1",
+      "arch": "all"
+    },
+    "python-apt-common": {
+      "version": "2.3.0ubuntu2",
+      "arch": "all"
+    },
+    "python-babel-localedata": {
+      "version": "2.8.0+dfsg.1-7",
+      "arch": "all"
+    },
+    "python3": {
+      "version": "3.10.4-0ubuntu2",
+      "arch": "amd64"
+    },
+    "python3-apport": {
+      "version": "2.20.11-0ubuntu82.1",
+      "arch": "all"
+    },
+    "python3-apt": {
+      "version": "2.3.0ubuntu2",
+      "arch": "amd64"
+    },
+    "python3-attr": {
+      "version": "21.2.0-1",
+      "arch": "all"
+    },
+    "python3-automat": {
+      "version": "20.2.0-1",
+      "arch": "all"
+    },
+    "python3-babel": {
+      "version": "2.8.0+dfsg.1-7",
+      "arch": "all"
+    },
+    "python3-bcrypt": {
+      "version": "3.2.0-1build1",
+      "arch": "amd64"
+    },
+    "python3-blinker": {
+      "version": "1.4+dfsg1-0.4",
+      "arch": "all"
+    },
+    "python3-certifi": {
+      "version": "2020.6.20-1",
+      "arch": "all"
+    },
+    "python3-cffi-backend": {
+      "version": "1.15.0-1build2",
+      "arch": "amd64"
+    },
+    "python3-chardet": {
+      "version": "4.0.0-1",
+      "arch": "all"
+    },
+    "python3-click": {
+      "version": "8.0.3-1",
+      "arch": "all"
+    },
+    "python3-colorama": {
+      "version": "0.4.4-1",
+      "arch": "all"
+    },
+    "python3-configobj": {
+      "version": "5.0.6-5",
+      "arch": "all"
+    },
+    "python3-constantly": {
+      "version": "15.1.0-2",
+      "arch": "all"
+    },
+    "python3-cryptography": {
+      "version": "3.4.8-1ubuntu2",
+      "arch": "amd64"
+    },
+    "python3-dbus": {
+      "version": "1.2.18-3build1",
+      "arch": "amd64"
+    },
+    "python3-distro": {
+      "version": "1.7.0-1",
+      "arch": "all"
+    },
+    "python3-distutils": {
+      "version": "3.10.4-0ubuntu1",
+      "arch": "all"
+    },
+    "python3-gdbm": {
+      "version": "3.10.4-0ubuntu1",
+      "arch": "amd64"
+    },
+    "python3-gi": {
+      "version": "3.42.0-3build1",
+      "arch": "amd64"
+    },
+    "python3-hamcrest": {
+      "version": "2.0.2-2",
+      "arch": "all"
+    },
+    "python3-httplib2": {
+      "version": "0.20.2-2",
+      "arch": "all"
+    },
+    "python3-hyperlink": {
+      "version": "21.0.0-3",
+      "arch": "all"
+    },
+    "python3-idna": {
+      "version": "3.3-1",
+      "arch": "all"
+    },
+    "python3-importlib-metadata": {
+      "version": "4.6.4-1",
+      "arch": "all"
+    },
+    "python3-incremental": {
+      "version": "21.3.0-1",
+      "arch": "all"
+    },
+    "python3-jeepney": {
+      "version": "0.7.1-3",
+      "arch": "all"
+    },
+    "python3-jinja2": {
+      "version": "3.0.3-1",
+      "arch": "all"
+    },
+    "python3-json-pointer": {
+      "version": "2.0-0ubuntu1",
+      "arch": "all"
+    },
+    "python3-jsonpatch": {
+      "version": "1.32-2",
+      "arch": "all"
+    },
+    "python3-jsonschema": {
+      "version": "3.2.0-0ubuntu2",
+      "arch": "all"
+    },
+    "python3-jwt": {
+      "version": "2.3.0-1",
+      "arch": "all"
+    },
+    "python3-keyring": {
+      "version": "23.5.0-1",
+      "arch": "all"
+    },
+    "python3-launchpadlib": {
+      "version": "1.10.16-1",
+      "arch": "all"
+    },
+    "python3-lazr.restfulclient": {
+      "version": "0.14.4-1",
+      "arch": "all"
+    },
+    "python3-lazr.uri": {
+      "version": "1.0.6-2",
+      "arch": "all"
+    },
+    "python3-lib2to3": {
+      "version": "3.10.4-0ubuntu1",
+      "arch": "all"
+    },
+    "python3-markupsafe": {
+      "version": "2.0.1-2build1",
+      "arch": "amd64"
+    },
+    "python3-minimal": {
+      "version": "3.10.4-0ubuntu2",
+      "arch": "amd64"
+    },
+    "python3-more-itertools": {
+      "version": "8.10.0-2",
+      "arch": "all"
+    },
+    "python3-netifaces": {
+      "version": "0.11.0-1build2",
+      "arch": "amd64"
+    },
+    "python3-newt": {
+      "version": "0.52.21-5ubuntu2",
+      "arch": "amd64"
+    },
+    "python3-oauthlib": {
+      "version": "3.2.0-1",
+      "arch": "all"
+    },
+    "python3-openssl": {
+      "version": "21.0.0-1",
+      "arch": "all"
+    },
+    "python3-pexpect": {
+      "version": "4.8.0-2ubuntu1",
+      "arch": "all"
+    },
+    "python3-pkg-resources": {
+      "version": "59.6.0-1.2",
+      "arch": "all"
+    },
+    "python3-problem-report": {
+      "version": "2.20.11-0ubuntu82.1",
+      "arch": "all"
+    },
+    "python3-ptyprocess": {
+      "version": "0.7.0-3",
+      "arch": "all"
+    },
+    "python3-pyasn1": {
+      "version": "0.4.8-1",
+      "arch": "all"
+    },
+    "python3-pyasn1-modules": {
+      "version": "0.2.1-1",
+      "arch": "all"
+    },
+    "python3-pyparsing": {
+      "version": "2.4.7-1",
+      "arch": "all"
+    },
+    "python3-pyrsistent": {
+      "version": "0.18.1-1build1",
+      "arch": "amd64"
+    },
+    "python3-requests": {
+      "version": "2.25.1+dfsg-2",
+      "arch": "all"
+    },
+    "python3-secretstorage": {
+      "version": "3.3.1-1",
+      "arch": "all"
+    },
+    "python3-serial": {
+      "version": "3.5-1",
+      "arch": "all"
+    },
+    "python3-service-identity": {
+      "version": "18.1.0-6",
+      "arch": "all"
+    },
+    "python3-setuptools": {
+      "version": "59.6.0-1.2",
+      "arch": "all"
+    },
+    "python3-six": {
+      "version": "1.16.0-3ubuntu1",
+      "arch": "all"
+    },
+    "python3-software-properties": {
+      "version": "0.99.22.1",
+      "arch": "all"
+    },
+    "python3-systemd": {
+      "version": "234-3ubuntu2",
+      "arch": "amd64"
+    },
+    "python3-twisted": {
+      "version": "22.1.0-2ubuntu2.1",
+      "arch": "all"
+    },
+    "python3-tz": {
+      "version": "2022.1-1",
+      "arch": "all"
+    },
+    "python3-urllib3": {
+      "version": "1.26.5-1~exp1",
+      "arch": "all"
+    },
+    "python3-wadllib": {
+      "version": "1.3.6-1",
+      "arch": "all"
+    },
+    "python3-yaml": {
+      "version": "5.4.1-1ubuntu1",
+      "arch": "amd64"
+    },
+    "python3-zipp": {
+      "version": "1.0.0-3",
+      "arch": "all"
+    },
+    "python3-zope.interface": {
+      "version": "5.4.0-1build1",
+      "arch": "amd64"
+    },
+    "python3.10": {
+      "version": "3.10.4-3",
+      "arch": "amd64"
+    },
+    "python3.10-minimal": {
+      "version": "3.10.4-3",
+      "arch": "amd64"
+    },
+    "readline-common": {
+      "version": "8.1.2-1",
+      "arch": "all"
+    },
+    "rsync": {
+      "version": "3.2.3-8ubuntu3",
+      "arch": "amd64"
+    },
+    "rsyslog": {
+      "version": "8.2112.0-2ubuntu2.2",
+      "arch": "amd64"
+    },
+    "run-one": {
+      "version": "1.17-0ubuntu1",
+      "arch": "all"
+    },
+    "sbsigntool": {
+      "version": "0.9.4-2ubuntu2",
+      "arch": "amd64"
+    },
+    "screen": {
+      "version": "4.9.0-1",
+      "arch": "amd64"
+    },
+    "secureboot-db": {
+      "version": "1.8",
+      "arch": "amd64"
+    },
+    "sed": {
+      "version": "4.8-1ubuntu2",
+      "arch": "amd64"
+    },
+    "sensible-utils": {
+      "version": "0.0.17",
+      "arch": "all"
+    },
+    "sg3-utils": {
+      "version": "1.46-1build1",
+      "arch": "amd64"
+    },
+    "sg3-utils-udev": {
+      "version": "1.46-1build1",
+      "arch": "all"
+    },
+    "shared-mime-info": {
+      "version": "2.1-2",
+      "arch": "amd64"
+    },
+    "snapd": {
+      "version": "2.55.3+22.04ubuntu1",
+      "arch": "amd64"
+    },
+    "software-properties-common": {
+      "version": "0.99.22.1",
+      "arch": "all"
+    },
+    "sosreport": {
+      "version": "4.3-1ubuntu2",
+      "arch": "amd64"
+    },
+    "squashfs-tools": {
+      "version": "1:4.5-3build1",
+      "arch": "amd64"
+    },
+    "ssh-import-id": {
+      "version": "5.11-0ubuntu1",
+      "arch": "all"
+    },
+    "strace": {
+      "version": "5.16-0ubuntu3",
+      "arch": "amd64"
+    },
+    "sudo": {
+      "version": "1.9.9-1ubuntu2",
+      "arch": "amd64"
+    },
+    "systemd": {
+      "version": "249.11-0ubuntu3.1",
+      "arch": "amd64"
+    },
+    "systemd-sysv": {
+      "version": "249.11-0ubuntu3.1",
+      "arch": "amd64"
+    },
+    "systemd-timesyncd": {
+      "version": "249.11-0ubuntu3.1",
+      "arch": "amd64"
+    },
+    "sysvinit-utils": {
+      "version": "3.01-1ubuntu1",
+      "arch": "amd64"
+    },
+    "tar": {
+      "version": "1.34+dfsg-1build3",
+      "arch": "amd64"
+    },
+    "tcl": {
+      "version": "8.6.11+1build2",
+      "arch": "amd64"
+    },
+    "tcl8.6": {
+      "version": "8.6.12+dfsg-1build1",
+      "arch": "amd64"
+    },
+    "tcpdump": {
+      "version": "4.99.1-3build2",
+      "arch": "amd64"
+    },
+    "telnet": {
+      "version": "0.17-44build1",
+      "arch": "amd64"
+    },
+    "thermald": {
+      "version": "2.4.9-1",
+      "arch": "amd64"
+    },
+    "thin-provisioning-tools": {
+      "version": "0.9.0-2ubuntu1",
+      "arch": "amd64"
+    },
+    "time": {
+      "version": "1.9-0.1build2",
+      "arch": "amd64"
+    },
+    "tmux": {
+      "version": "3.2a-4build1",
+      "arch": "amd64"
+    },
+    "tnftp": {
+      "version": "20210827-4build1",
+      "arch": "amd64"
+    },
+    "tpm-udev": {
+      "version": "0.6",
+      "arch": "all"
+    },
+    "tzdata": {
+      "version": "2022a-0ubuntu1",
+      "arch": "all"
+    },
+    "ubuntu-advantage-tools": {
+      "version": "27.8~22.04.1",
+      "arch": "amd64"
+    },
+    "ubuntu-keyring": {
+      "version": "2021.03.26",
+      "arch": "all"
+    },
+    "ubuntu-minimal": {
+      "version": "1.481",
+      "arch": "amd64"
+    },
+    "ucf": {
+      "version": "3.0043",
+      "arch": "all"
+    },
+    "udev": {
+      "version": "249.11-0ubuntu3.1",
+      "arch": "amd64"
+    },
+    "udisks2": {
+      "version": "2.9.4-1ubuntu2",
+      "arch": "amd64"
+    },
+    "ufw": {
+      "version": "0.36.1-4build1",
+      "arch": "all"
+    },
+    "upower": {
+      "version": "0.99.17-1",
+      "arch": "amd64"
+    },
+    "usb-modeswitch": {
+      "version": "2.6.1-3ubuntu2",
+      "arch": "amd64"
+    },
+    "usb-modeswitch-data": {
+      "version": "20191128-4",
+      "arch": "all"
+    },
+    "usb.ids": {
+      "version": "2022.04.02-1",
+      "arch": "all"
+    },
+    "usbmuxd": {
+      "version": "1.1.1-2build2",
+      "arch": "amd64"
+    },
+    "usrmerge": {
+      "version": "25ubuntu2",
+      "arch": "all"
+    },
+    "util-linux": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "uuid-runtime": {
+      "version": "2.37.2-4ubuntu3",
+      "arch": "amd64"
+    },
+    "vim": {
+      "version": "2:8.2.3995-1ubuntu2",
+      "arch": "amd64"
+    },
+    "vim-common": {
+      "version": "2:8.2.3995-1ubuntu2",
+      "arch": "all"
+    },
+    "vim-runtime": {
+      "version": "2:8.2.3995-1ubuntu2",
+      "arch": "all"
+    },
+    "vim-tiny": {
+      "version": "2:8.2.3995-1ubuntu2",
+      "arch": "amd64"
+    },
+    "wget": {
+      "version": "1.21.2-2ubuntu1",
+      "arch": "amd64"
+    },
+    "whiptail": {
+      "version": "0.52.21-5ubuntu2",
+      "arch": "amd64"
+    },
+    "wireless-regdb": {
+      "version": "2021.08.28-0ubuntu1",
+      "arch": "all"
+    },
+    "xdg-user-dirs": {
+      "version": "0.17-2ubuntu4",
+      "arch": "amd64"
+    },
+    "xfsprogs": {
+      "version": "5.13.0-1ubuntu2",
+      "arch": "amd64"
+    },
+    "xkb-data": {
+      "version": "2.33-1",
+      "arch": "all"
+    },
+    "xxd": {
+      "version": "2:8.2.3995-1ubuntu2",
+      "arch": "amd64"
+    },
+    "xz-utils": {
+      "version": "5.2.5-2ubuntu1",
+      "arch": "amd64"
+    },
+    "zerofree": {
+      "version": "1.1.1-1build3",
+      "arch": "amd64"
+    },
+    "zlib1g": {
+      "version": "1:1.2.11.dfsg-2ubuntu9",
+      "arch": "amd64"
+    },
+    "zstd": {
+      "version": "1.4.8+dfsg-3build1",
+      "arch": "amd64"
+    }
+  },
+  "platform": "ubuntu",
+  "platform_family": "debian",
+  "platform_version": "22.04",
+  "root_group": "root",
+  "shard_seed": 14302820,
+  "shells": [
+    "/bin/sh",
+    "/bin/bash",
+    "/usr/bin/bash",
+    "/bin/rbash",
+    "/usr/bin/rbash",
+    "/usr/bin/sh",
+    "/bin/dash",
+    "/usr/bin/dash",
+    "/usr/bin/tmux",
+    "/usr/bin/screen"
+  ],
+  "time": {
+    "timezone": "GMT"
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "virtualization": {
+    "systems": {
+    }
+  }
+}

--- a/platforms.json
+++ b/platforms.json
@@ -265,6 +265,10 @@
     "20.04": {
       "deprecated": false,
       "path": "lib/fauxhai/platforms/ubuntu/20.04.json"
+    },
+    "22.04": {
+      "deprecated": false,
+      "path": "lib/fauxhai/platforms/ubuntu/22.04.json"
     }
   },
   "windows": {


### PR DESCRIPTION
## Description
This PR adds support for Ubuntu 22.04 (jammy jellyfish).

- All changes are ported from https://github.com/chefspec/fauxhai/pull/369 from @buck3tsec.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
