### PR TITLE
Added RedHat 9

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -10,6 +10,7 @@ This file lists each platform known to Fauxhai and the available versions for ea
 ### almalinux
 
 - 8
+- 9
 
 ### amazon
 
@@ -103,10 +104,12 @@ This file lists each platform known to Fauxhai and the available versions for ea
 - 7.8
 - 7.9
 - 8
+- 9
 
 ### rocky
 
 - 8
+- 9
 
 ### smartos
 

--- a/lib/fauxhai/platforms/redhat/9.json
+++ b/lib/fauxhai/platforms/redhat/9.json
@@ -1,0 +1,4860 @@
+{
+  "block_device": {
+    "xvda": {
+      "size": "33554432",
+      "removable": "0",
+      "state": "Connected",
+      "rotational": "0",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "17.9.26",
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.9.26/lib",
+      "chef_effortless": null
+    },
+    "ohai": {
+      "version": "17.9.1",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.9.1/lib/ohai"
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "lo": {
+          "tx": {
+            "queuelen": "1",
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "carrier": 0,
+            "collisions": 0
+          },
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0
+          }
+        },
+        "eth0": {
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "collisions": 0,
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "current_user": "fauxhai",
+  "dmi": {
+    "dmidecode_version": "3.5",
+    "smbios_version": "2.7",
+    "structures": {
+      "count": "12",
+      "size": "426"
+    },
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "Xen",
+          "Version": "4.11.amazon",
+          "Release Date": "08/24/2006",
+          "Address": "0xE8000",
+          "Runtime Size": "96 kB",
+          "ROM Size": "64 kB",
+          "Characteristics": {
+            "Targeted content distribution is supported": null
+          },
+          "BIOS Revision": "4.11"
+        }
+      ],
+      "vendor": "Xen",
+      "version": "4.11.amazon",
+      "release_date": "08/24/2006",
+      "address": "0xE8000",
+      "runtime_size": "96 kB",
+      "rom_size": "64 kB",
+      "bios_revision": "4.11"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0100",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "Xen",
+          "Product Name": "HVM domU",
+          "Version": "4.11.amazon",
+          "Serial Number": "ec2c333a-7944-691f-056f-b6ea5cbfce80",
+          "UUID": "ec2c333a-7944-691f-056f-b6ea5cbfce80",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Not Specified"
+        }
+      ],
+      "manufacturer": "Xen",
+      "product_name": "HVM domU",
+      "version": "4.11.amazon",
+      "serial_number": "ec2c333a-7944-691f-056f-b6ea5cbfce80",
+      "uuid": "ec2c333a-7944-691f-056f-b6ea5cbfce80",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Not Specified"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0300",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Xen",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "Unknown",
+          "OEM Information": "0x00000000",
+          "Height": "Unspecified",
+          "Number Of Power Cords": "Unspecified",
+          "Contained Elements": "0"
+        }
+      ],
+      "manufacturer": "Xen",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "Unknown",
+      "oem_information": "0x00000000",
+      "height": "Unspecified",
+      "number_of_power_cords": "Unspecified",
+      "contained_elements": "0"
+    },
+    "processor": {
+      "all_records": [
+        {
+          "record_id": "0x0401",
+          "size": "4",
+          "application_identifier": "Processor Information",
+          "Socket Designation": "CPU 1",
+          "Type": "Central Processor",
+          "Family": "Other",
+          "Manufacturer": "Intel",
+          "ID": "F1 06 04 00 FF FB 8B 17",
+          "Version": "Not Specified",
+          "Voltage": "Unknown",
+          "External Clock": "Unknown",
+          "Max Speed": "2300 MHz",
+          "Current Speed": "2300 MHz",
+          "Status": "Populated, Enabled",
+          "Upgrade": "Other",
+          "L1 Cache Handle": "Not Provided",
+          "L2 Cache Handle": "Not Provided",
+          "L3 Cache Handle": "Not Provided",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Part Number": "Not Specified"
+        },
+        {
+          "record_id": "0x0402",
+          "size": "4",
+          "application_identifier": "Processor Information",
+          "Socket Designation": "CPU 2",
+          "Type": "Central Processor",
+          "Family": "Other",
+          "Manufacturer": "Intel",
+          "ID": "F1 06 04 00 FF FB 8B 17",
+          "Version": "Not Specified",
+          "Voltage": "Unknown",
+          "External Clock": "Unknown",
+          "Max Speed": "2300 MHz",
+          "Current Speed": "2300 MHz",
+          "Status": "Populated, Enabled",
+          "Upgrade": "Other",
+          "L1 Cache Handle": "Not Provided",
+          "L2 Cache Handle": "Not Provided",
+          "L3 Cache Handle": "Not Provided",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Part Number": "Not Specified"
+        }
+      ],
+      "type": "Central Processor",
+      "family": "Other",
+      "manufacturer": "Intel",
+      "id": "F1 06 04 00 FF FB 8B 17",
+      "version": "Not Specified",
+      "voltage": "Unknown",
+      "external_clock": "Unknown",
+      "max_speed": "2300 MHz",
+      "current_speed": "2300 MHz",
+      "status": "Populated, Enabled",
+      "upgrade": "Other",
+      "l1_cache_handle": "Not Provided",
+      "l2_cache_handle": "Not Provided",
+      "l3_cache_handle": "Not Provided",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "part_number": "Not Specified"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0B00",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "Xen"
+        }
+      ],
+      "string_1": "Xen"
+    }
+  },
+  "domain": "local",
+  "filesystem": {
+    "by_device": {
+      "devtmpfs": {
+        "kb_size": "4096",
+        "kb_used": "0",
+        "kb_available": "4096",
+        "percent_used": "0%",
+        "total_inodes": "456617",
+        "inodes_used": "305",
+        "inodes_available": "456312",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4096k",
+          "nr_inodes=456617",
+          "mode=755",
+          "inode64"
+        ],
+        "mounts": [
+          "/dev"
+        ]
+      },
+      "tmpfs": {
+        "kb_size": "373224",
+        "kb_used": "0",
+        "kb_available": "373224",
+        "percent_used": "0%",
+        "total_inodes": "93306",
+        "inodes_used": "14",
+        "inodes_available": "93292",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=373224k",
+          "nr_inodes=93306",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "mounts": [
+          "/dev/shm",
+          "/run",
+          "/run/user/1000"
+        ]
+      },
+      "/dev/xvda4": {
+        "kb_size": "15890412",
+        "kb_used": "1630072",
+        "kb_available": "14260340",
+        "percent_used": "11%",
+        "total_inodes": "7977968",
+        "inodes_used": "46240",
+        "inodes_available": "7931728",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "2cfdcca4-d3e3-40cb-b58e-0bed76bdceec",
+        "label": "root",
+        "mounts": [
+          "/"
+        ]
+      },
+      "/dev/xvda3": {
+        "kb_size": "548864",
+        "kb_used": "164608",
+        "kb_available": "384256",
+        "percent_used": "30%",
+        "total_inodes": "307200",
+        "inodes_used": "307",
+        "inodes_available": "306893",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "1dde521c-d910-4d8f-a14a-2704a5d4dbd4",
+        "label": "boot",
+        "mounts": [
+          "/boot"
+        ]
+      },
+      "/dev/xvda2": {
+        "kb_size": "204580",
+        "kb_used": "7128",
+        "kb_available": "197452",
+        "percent_used": "4%",
+        "fs_type": "vfat",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fmask=0077",
+          "dmask=0077",
+          "codepage=437",
+          "iocharset=ascii",
+          "shortname=winnt",
+          "errors=remount-ro"
+        ],
+        "uuid": "7B77-95E7",
+        "mounts": [
+          "/efi",
+          "/boot/efi"
+        ]
+      },
+      "proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc"
+        ]
+      },
+      "sysfs": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys"
+        ]
+      },
+      "securityfs": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/security"
+        ]
+      },
+      "devpts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "mounts": [
+          "/dev/pts"
+        ]
+      },
+      "cgroup2": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup"
+        ]
+      },
+      "pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/fs/pstore"
+        ]
+      },
+      "bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/sys/fs/bpf"
+        ]
+      },
+      "selinuxfs": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/selinux"
+        ]
+      },
+      "systemd-1": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=37",
+          "pgrp=1",
+          "timeout=120",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=14915"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc",
+          "/efi"
+        ]
+      },
+      "hugetlbfs": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "mounts": [
+          "/dev/hugepages"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/dev/mqueue"
+        ]
+      },
+      "debugfs": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/debug"
+        ]
+      },
+      "tracefs": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/tracing"
+        ]
+      },
+      "fusectl": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/fuse/connections"
+        ]
+      },
+      "configfs": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/config"
+        ]
+      },
+      "none": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "mounts": [
+          "/run/credentials/systemd-sysctl.service",
+          "/run/credentials/systemd-sysusers.service",
+          "/run/credentials/systemd-tmpfiles-setup-dev.service",
+          "/run/credentials/systemd-tmpfiles-setup.service"
+        ]
+      },
+      "/dev/xvda": {
+        "mounts": []
+      },
+      "/dev/xvda1": {
+        "mounts": []
+      }
+    },
+    "by_mountpoint": {
+      "/dev": {
+        "kb_size": "4096",
+        "kb_used": "0",
+        "kb_available": "4096",
+        "percent_used": "0%",
+        "total_inodes": "456617",
+        "inodes_used": "305",
+        "inodes_available": "456312",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4096k",
+          "nr_inodes=456617",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "devtmpfs"
+        ]
+      },
+      "/dev/shm": {
+        "kb_size": "1866128",
+        "kb_used": "0",
+        "kb_available": "1866128",
+        "percent_used": "0%",
+        "total_inodes": "466532",
+        "inodes_used": "1",
+        "inodes_available": "466531",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/run": {
+        "kb_size": "746452",
+        "kb_used": "16916",
+        "kb_available": "729536",
+        "percent_used": "3%",
+        "total_inodes": "819200",
+        "inodes_used": "520",
+        "inodes_available": "818680",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "size=746452k",
+          "nr_inodes=819200",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/": {
+        "kb_size": "15890412",
+        "kb_used": "1630072",
+        "kb_available": "14260340",
+        "percent_used": "11%",
+        "total_inodes": "7977968",
+        "inodes_used": "46240",
+        "inodes_available": "7931728",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "2cfdcca4-d3e3-40cb-b58e-0bed76bdceec",
+        "label": "root",
+        "devices": [
+          "/dev/xvda4"
+        ]
+      },
+      "/boot": {
+        "kb_size": "548864",
+        "kb_used": "164608",
+        "kb_available": "384256",
+        "percent_used": "30%",
+        "total_inodes": "307200",
+        "inodes_used": "307",
+        "inodes_available": "306893",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "1dde521c-d910-4d8f-a14a-2704a5d4dbd4",
+        "label": "boot",
+        "devices": [
+          "/dev/xvda3"
+        ]
+      },
+      "/efi": {
+        "kb_size": "204580",
+        "kb_used": "7128",
+        "kb_available": "197452",
+        "percent_used": "4%",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=37",
+          "pgrp=1",
+          "timeout=120",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=14915"
+        ],
+        "uuid": "7B77-95E7",
+        "devices": [
+          "/dev/xvda2",
+          "systemd-1"
+        ]
+      },
+      "/run/user/1000": {
+        "kb_size": "373224",
+        "kb_used": "0",
+        "kb_available": "373224",
+        "percent_used": "0%",
+        "total_inodes": "93306",
+        "inodes_used": "14",
+        "inodes_available": "93292",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=373224k",
+          "nr_inodes=93306",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "proc"
+        ]
+      },
+      "/sys": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "sysfs"
+        ]
+      },
+      "/sys/kernel/security": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "securityfs"
+        ]
+      },
+      "/dev/pts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "devices": [
+          "devpts"
+        ]
+      },
+      "/sys/fs/cgroup": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ],
+        "devices": [
+          "cgroup2"
+        ]
+      },
+      "/sys/fs/pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "pstore"
+        ]
+      },
+      "/sys/fs/bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "devices": [
+          "bpf"
+        ]
+      },
+      "/sys/fs/selinux": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "selinuxfs"
+        ]
+      },
+      "/proc/sys/fs/binfmt_misc": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=29",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=19623"
+        ],
+        "devices": [
+          "systemd-1"
+        ]
+      },
+      "/dev/hugepages": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "devices": [
+          "hugetlbfs"
+        ]
+      },
+      "/dev/mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "mqueue"
+        ]
+      },
+      "/sys/kernel/debug": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "debugfs"
+        ]
+      },
+      "/sys/kernel/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "tracefs"
+        ]
+      },
+      "/sys/fs/fuse/connections": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "fusectl"
+        ]
+      },
+      "/sys/kernel/config": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "configfs"
+        ]
+      },
+      "/run/credentials/systemd-sysctl.service": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/run/credentials/systemd-sysusers.service": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/boot/efi": {
+        "fs_type": "vfat",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fmask=0077",
+          "dmask=0077",
+          "codepage=437",
+          "iocharset=ascii",
+          "shortname=winnt",
+          "errors=remount-ro"
+        ],
+        "uuid": "7B77-95E7",
+        "devices": [
+          "/dev/xvda2"
+        ]
+      },
+      "/run/credentials/systemd-tmpfiles-setup.service": {
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ],
+        "devices": [
+          "none"
+        ]
+      }
+    },
+    "by_pair": {
+      "devtmpfs,/dev": {
+        "device": "devtmpfs",
+        "kb_size": "4096",
+        "kb_used": "0",
+        "kb_available": "4096",
+        "percent_used": "0%",
+        "mount": "/dev",
+        "total_inodes": "456617",
+        "inodes_used": "305",
+        "inodes_available": "456312",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4096k",
+          "nr_inodes=456617",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "tmpfs,/dev/shm": {
+        "device": "tmpfs",
+        "kb_size": "1866128",
+        "kb_used": "0",
+        "kb_available": "1866128",
+        "percent_used": "0%",
+        "mount": "/dev/shm",
+        "total_inodes": "466532",
+        "inodes_used": "1",
+        "inodes_available": "466531",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "inode64"
+        ]
+      },
+      "tmpfs,/run": {
+        "device": "tmpfs",
+        "kb_size": "746452",
+        "kb_used": "16916",
+        "kb_available": "729536",
+        "percent_used": "3%",
+        "mount": "/run",
+        "total_inodes": "819200",
+        "inodes_used": "520",
+        "inodes_available": "818680",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "size=746452k",
+          "nr_inodes=819200",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "/dev/xvda4,/": {
+        "device": "/dev/xvda4",
+        "kb_size": "15890412",
+        "kb_used": "1630072",
+        "kb_available": "14260340",
+        "percent_used": "11%",
+        "mount": "/",
+        "total_inodes": "7977968",
+        "inodes_used": "46240",
+        "inodes_available": "7931728",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "2cfdcca4-d3e3-40cb-b58e-0bed76bdceec",
+        "label": "root"
+      },
+      "/dev/xvda3,/boot": {
+        "device": "/dev/xvda3",
+        "kb_size": "548864",
+        "kb_used": "164608",
+        "kb_available": "384256",
+        "percent_used": "30%",
+        "mount": "/boot",
+        "total_inodes": "307200",
+        "inodes_used": "307",
+        "inodes_available": "306893",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "1dde521c-d910-4d8f-a14a-2704a5d4dbd4",
+        "label": "boot"
+      },
+      "/dev/xvda2,/efi": {
+        "device": "/dev/xvda2",
+        "kb_size": "204580",
+        "kb_used": "7128",
+        "kb_available": "197452",
+        "percent_used": "4%",
+        "mount": "/efi",
+        "fs_type": "vfat",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fmask=0077",
+          "dmask=0077",
+          "codepage=437",
+          "iocharset=ascii",
+          "shortname=winnt",
+          "errors=remount-ro"
+        ],
+        "uuid": "7B77-95E7"
+      },
+      "tmpfs,/run/user/1000": {
+        "device": "tmpfs",
+        "kb_size": "373224",
+        "kb_used": "0",
+        "kb_available": "373224",
+        "percent_used": "0%",
+        "mount": "/run/user/1000",
+        "total_inodes": "93306",
+        "inodes_used": "14",
+        "inodes_available": "93292",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=373224k",
+          "nr_inodes=93306",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ]
+      },
+      "proc,/proc": {
+        "device": "proc",
+        "mount": "/proc",
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "sysfs,/sys": {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "securityfs,/sys/kernel/security": {
+        "device": "securityfs",
+        "mount": "/sys/kernel/security",
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "devpts,/dev/pts": {
+        "device": "devpts",
+        "mount": "/dev/pts",
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "cgroup2,/sys/fs/cgroup": {
+        "device": "cgroup2",
+        "mount": "/sys/fs/cgroup",
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ]
+      },
+      "pstore,/sys/fs/pstore": {
+        "device": "pstore",
+        "mount": "/sys/fs/pstore",
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "bpf,/sys/fs/bpf": {
+        "device": "bpf",
+        "mount": "/sys/fs/bpf",
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "selinuxfs,/sys/fs/selinux": {
+        "device": "selinuxfs",
+        "mount": "/sys/fs/selinux",
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "systemd-1,/proc/sys/fs/binfmt_misc": {
+        "device": "systemd-1",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=29",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=19623"
+        ]
+      },
+      "hugetlbfs,/dev/hugepages": {
+        "device": "hugetlbfs",
+        "mount": "/dev/hugepages",
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "mount": "/dev/mqueue",
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "debugfs,/sys/kernel/debug": {
+        "device": "debugfs",
+        "mount": "/sys/kernel/debug",
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "tracefs,/sys/kernel/tracing": {
+        "device": "tracefs",
+        "mount": "/sys/kernel/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "fusectl,/sys/fs/fuse/connections": {
+        "device": "fusectl",
+        "mount": "/sys/fs/fuse/connections",
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "configfs,/sys/kernel/config": {
+        "device": "configfs",
+        "mount": "/sys/kernel/config",
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "none,/run/credentials/systemd-sysctl.service": {
+        "device": "none",
+        "mount": "/run/credentials/systemd-sysctl.service",
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ]
+      },
+      "none,/run/credentials/systemd-sysusers.service": {
+        "device": "none",
+        "mount": "/run/credentials/systemd-sysusers.service",
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ]
+      },
+      "none,/run/credentials/systemd-tmpfiles-setup-dev.service": {
+        "device": "none",
+        "mount": "/run/credentials/systemd-tmpfiles-setup-dev.service",
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ]
+      },
+      "systemd-1,/efi": {
+        "device": "systemd-1",
+        "mount": "/efi",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=37",
+          "pgrp=1",
+          "timeout=120",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=14915"
+        ]
+      },
+      "/dev/xvda2,/boot/efi": {
+        "device": "/dev/xvda2",
+        "mount": "/boot/efi",
+        "fs_type": "vfat",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fmask=0077",
+          "dmask=0077",
+          "codepage=437",
+          "iocharset=ascii",
+          "shortname=winnt",
+          "errors=remount-ro"
+        ],
+        "uuid": "7B77-95E7"
+      },
+      "none,/run/credentials/systemd-tmpfiles-setup.service": {
+        "device": "none",
+        "mount": "/run/credentials/systemd-tmpfiles-setup.service",
+        "fs_type": "ramfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "mode=700"
+        ]
+      },
+      "/dev/xvda,": {
+        "device": "/dev/xvda"
+      },
+      "/dev/xvda1,": {
+        "device": "/dev/xvda1"
+      }
+    }
+  },
+  "fips": {
+    "kernel": {
+      "enabled": true
+    }
+  },
+  "fqdn": "fauxhai.local",
+  "hostname": "Fauxhai",
+  "idle": "30 days 15 hours 07 minutes 30 seconds",
+  "idletime_seconds": 2646450,
+  "init_package": "systemd",
+  "ipaddress": "10.0.0.2",
+  "kernel": {
+    "name": "Linux",
+    "release": "5.14.0-362.8.1.el9_3.x86_64",
+    "version": "#1 SMP PREEMPT_DYNAMIC Tue Oct 3 11:12:36 EDT 2023",
+    "machine": "x86_64",
+    "processor": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "tls": {
+        "size": "151552",
+        "refcount": "0"
+      },
+      "rfkill": {
+        "size": "40960",
+        "refcount": "1"
+      },
+      "vfat": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "fat": {
+        "size": "102400",
+        "refcount": "1"
+      },
+      "intel_rapl_msr": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "cirrus": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "intel_rapl_common": {
+        "size": "36864",
+        "refcount": "1"
+      },
+      "drm_shmem_helper": {
+        "size": "28672",
+        "refcount": "1"
+      },
+      "rapl": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "drm_kms_helper": {
+        "size": "245760",
+        "refcount": "3"
+      },
+      "syscopyarea": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysfillrect": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "pcspkr": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "sysimgblt": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "i2c_piix4": {
+        "size": "32768",
+        "refcount": "0"
+      },
+      "fuse": {
+        "size": "212992",
+        "refcount": "1"
+      },
+      "drm": {
+        "size": "704512",
+        "refcount": "4"
+      },
+      "xfs": {
+        "size": "2473984",
+        "refcount": "2"
+      },
+      "libcrc32c": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ata_generic": {
+        "size": "16384",
+        "refcount": "0",
+        "version": "0.2.15"
+      },
+      "crct10dif_pclmul": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "crc32_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ata_piix": {
+        "size": "45056",
+        "refcount": "0",
+        "version": "2.13"
+      },
+      "crc32c_intel": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "libata": {
+        "size": "479232",
+        "refcount": "2",
+        "version": "3.00"
+      },
+      "xen_netfront": {
+        "size": "49152",
+        "refcount": "1"
+      },
+      "xen_blkfront": {
+        "size": "57344",
+        "refcount": "4"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "dm_mirror": {
+        "size": "32768",
+        "refcount": "0"
+      },
+      "dm_region_hash": {
+        "size": "28672",
+        "refcount": "1"
+      },
+      "dm_log": {
+        "size": "28672",
+        "refcount": "2"
+      },
+      "dm_mod": {
+        "size": "237568",
+        "refcount": "2"
+      }
+    }
+  },
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "3.0.3",
+      "release_date": "2021-11-24",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems"
+    },
+    "powershell": null
+  },
+  "lsb": {},
+  "macaddress": "11:11:11:11:11:11",
+  "machinename": "Fauxhai",
+  "memory": {
+    "total": "1048576kB"
+  },
+  "network": {
+    "interfaces": {
+      "lo": {
+        "mtu": "65536",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Loopback",
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "prefixlen": "8",
+            "netmask": "255.0.0.0",
+            "scope": "Node",
+            "ip_scope": "LOOPBACK"
+          },
+          "::1": {
+            "family": "inet6",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": [],
+            "ip_scope": "LINK LOCAL LOOPBACK"
+          }
+        },
+        "state": "unknown"
+      },
+      "eth0": {
+        "type": "eth",
+        "number": "0",
+        "mtu": "1500",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Ethernet",
+        "addresses": {
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
+          },
+          "10.0.0.2": {
+            "family": "inet",
+            "prefixlen": "24",
+            "netmask": "255.255.255.0",
+            "broadcast": "10.0.0.255",
+            "scope": "Global",
+            "ip_scope": "RFC1918 PRIVATE"
+          },
+          "fe80::11:1111:1111:1111": {
+            "family": "inet6",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": [],
+            "ip_scope": "LINK LOCAL UNICAST"
+          }
+        },
+        "state": "up",
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "10.0.0.1"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
+            "scope": "link",
+            "proto": "kernel",
+            "src": "10.0.0.2"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ],
+        "ring_params": {}
+      }
+    },
+    "default_interface": "eth0",
+    "default_gateway": "10.0.0.1"
+  },
+  "ohai_time": 1699972797.286854,
+  "os": "linux",
+  "os_release": {
+    "name": "Red Hat Enterprise Linux",
+    "version": "9.3 (Plow)",
+    "id": "rhel",
+    "id_like": [
+      "fedora"
+    ],
+    "version_id": "9.3",
+    "platform_id": "platform:el9",
+    "pretty_name": "Red Hat Enterprise Linux 9.3 (Plow)",
+    "ansi_color": "0;31",
+    "logo": "fedora-logo-icon",
+    "cpe_name": "cpe:/o:redhat:enterprise_linux:9::baseos",
+    "home_url": "https://www.redhat.com/",
+    "documentation_url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9",
+    "bug_report_url": "https://bugzilla.redhat.com/",
+    "redhat_bugzilla_product": "Red Hat Enterprise Linux 9",
+    "redhat_bugzilla_product_version": "9.3",
+    "redhat_support_product": "Red Hat Enterprise Linux",
+    "redhat_support_product_version": "9.3"
+  },
+  "os_version": "5.14.0-362.8.1.el9_3.x86_64",
+  "packages": {
+    "libgcc": {
+      "epoch": "0",
+      "version": "11.4.1",
+      "release": "2.1.el9",
+      "installdate": "1699429312",
+      "arch": "x86_64"
+    },
+    "crypto-policies": {
+      "epoch": "0",
+      "version": "20230731",
+      "release": "1.git94f0e2c.el9_3.1",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "tzdata": {
+      "epoch": "0",
+      "version": "2023c",
+      "release": "1.el9",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "subscription-manager-rhsm-certificates": {
+      "epoch": "0",
+      "version": "20220623",
+      "release": "1.el9",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "libreport-filesystem": {
+      "epoch": "0",
+      "version": "2.15.2",
+      "release": "6.el9",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "hwdata": {
+      "epoch": "0",
+      "version": "0.348",
+      "release": "9.11.el9",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "dnf-data": {
+      "epoch": "0",
+      "version": "4.14.0",
+      "release": "8.el9",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "geolite2-country": {
+      "epoch": "0",
+      "version": "20191217",
+      "release": "6.el9",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "geolite2-city": {
+      "epoch": "0",
+      "version": "20191217",
+      "release": "6.el9",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "gawk-all-langpacks": {
+      "epoch": "0",
+      "version": "5.1.0",
+      "release": "6.el9",
+      "installdate": "1699429312",
+      "arch": "x86_64"
+    },
+    "redhat-release-eula": {
+      "epoch": "0",
+      "version": "9.3",
+      "release": "0.5.el9",
+      "installdate": "1699429312",
+      "arch": "x86_64"
+    },
+    "redhat-release": {
+      "epoch": "0",
+      "version": "9.3",
+      "release": "0.5.el9",
+      "installdate": "1699429312",
+      "arch": "x86_64"
+    },
+    "setup": {
+      "epoch": "0",
+      "version": "2.13.7",
+      "release": "9.el9",
+      "installdate": "1699429312",
+      "arch": "noarch"
+    },
+    "filesystem": {
+      "epoch": "0",
+      "version": "3.16",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "efi-filesystem": {
+      "epoch": "0",
+      "version": "6",
+      "release": "2.el9_0",
+      "installdate": "1699429313",
+      "arch": "noarch"
+    },
+    "basesystem": {
+      "epoch": "0",
+      "version": "11",
+      "release": "13.el9",
+      "installdate": "1699429313",
+      "arch": "noarch"
+    },
+    "python3-setuptools-wheel": {
+      "epoch": "0",
+      "version": "53.0.0",
+      "release": "12.el9",
+      "installdate": "1699429313",
+      "arch": "noarch"
+    },
+    "publicsuffix-list-dafsa": {
+      "epoch": "0",
+      "version": "20210518",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "noarch"
+    },
+    "pcre2-syntax": {
+      "epoch": "0",
+      "version": "10.40",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "noarch"
+    },
+    "ncurses-base": {
+      "epoch": "0",
+      "version": "6.2",
+      "release": "10.20210508.el9",
+      "installdate": "1699429313",
+      "arch": "noarch"
+    },
+    "glibc-gconv-extra": {
+      "epoch": "0",
+      "version": "2.34",
+      "release": "83.el9_3.7",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "glibc-langpack-en": {
+      "epoch": "0",
+      "version": "2.34",
+      "release": "83.el9_3.7",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "glibc-common": {
+      "epoch": "0",
+      "version": "2.34",
+      "release": "83.el9_3.7",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "glibc": {
+      "epoch": "0",
+      "version": "2.34",
+      "release": "83.el9_3.7",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "ncurses-libs": {
+      "epoch": "0",
+      "version": "6.2",
+      "release": "10.20210508.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "bash": {
+      "epoch": "0",
+      "version": "5.1.8",
+      "release": "6.el9_1",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "zlib": {
+      "epoch": "0",
+      "version": "1.2.11",
+      "release": "40.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "xz-libs": {
+      "epoch": "0",
+      "version": "5.2.5",
+      "release": "8.el9_0",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "popt": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "8.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libzstd": {
+      "epoch": "0",
+      "version": "1.5.1",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libcap": {
+      "epoch": "0",
+      "version": "2.48",
+      "release": "9.el9_2",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libuuid": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "15.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libxcrypt": {
+      "epoch": "0",
+      "version": "4.4.18",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "bzip2-libs": {
+      "epoch": "0",
+      "version": "1.0.8",
+      "release": "8.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "sqlite-libs": {
+      "epoch": "0",
+      "version": "3.34.1",
+      "release": "6.el9_1",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libstdc++": {
+      "epoch": "0",
+      "version": "11.4.1",
+      "release": "2.1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libcom_err": {
+      "epoch": "0",
+      "version": "1.46.5",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libxml2": {
+      "epoch": "0",
+      "version": "2.9.13",
+      "release": "4.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "elfutils-libelf": {
+      "epoch": "0",
+      "version": "0.189",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libcap-ng": {
+      "epoch": "0",
+      "version": "0.8.2",
+      "release": "7.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "audit-libs": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "104.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "nspr": {
+      "epoch": "0",
+      "version": "4.35.0",
+      "release": "3.el9_2",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "nss-util": {
+      "epoch": "0",
+      "version": "3.90.0",
+      "release": "3.el9_2",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "readline": {
+      "epoch": "0",
+      "version": "8.1",
+      "release": "4.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libgpg-error": {
+      "epoch": "0",
+      "version": "1.42",
+      "release": "5.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libunistring": {
+      "epoch": "0",
+      "version": "0.9.10",
+      "release": "15.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "lua-libs": {
+      "epoch": "0",
+      "version": "5.4.4",
+      "release": "4.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "alternatives": {
+      "epoch": "0",
+      "version": "1.24",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "dmidecode": {
+      "epoch": "1",
+      "version": "3.5",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "expat": {
+      "epoch": "0",
+      "version": "2.5.0",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libffi": {
+      "epoch": "0",
+      "version": "3.4.2",
+      "release": "8.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "p11-kit": {
+      "epoch": "0",
+      "version": "0.24.1",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libnl3": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libsepol": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libtalloc": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "lz4-libs": {
+      "epoch": "0",
+      "version": "1.9.3",
+      "release": "5.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "pcre2": {
+      "epoch": "0",
+      "version": "10.40",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libselinux": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "findutils": {
+      "epoch": "1",
+      "version": "4.8.0",
+      "release": "6.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libsemanage": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libidn2": {
+      "epoch": "0",
+      "version": "2.3.0",
+      "release": "7.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "gmp": {
+      "epoch": "1",
+      "version": "6.2.0",
+      "release": "13.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "json-c": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "11.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "keyutils-libs": {
+      "epoch": "0",
+      "version": "1.6.3",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libmnl": {
+      "epoch": "0",
+      "version": "1.0.4",
+      "release": "15.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libsmartcols": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "15.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libtevent": {
+      "epoch": "0",
+      "version": "0.14.1",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libgcrypt": {
+      "epoch": "0",
+      "version": "1.10.0",
+      "release": "10.el9_2",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "gdisk": {
+      "epoch": "0",
+      "version": "1.0.7",
+      "release": "5.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "file-libs": {
+      "epoch": "0",
+      "version": "5.39",
+      "release": "14.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "file": {
+      "epoch": "0",
+      "version": "5.39",
+      "release": "14.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libedit": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "38.20210216cvs.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "psmisc": {
+      "epoch": "0",
+      "version": "23.4",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "efivar-libs": {
+      "epoch": "0",
+      "version": "38",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "gdbm-libs": {
+      "epoch": "1",
+      "version": "1.19",
+      "release": "4.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libattr": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libacl": {
+      "epoch": "0",
+      "version": "2.3.1",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "sed": {
+      "epoch": "0",
+      "version": "4.8",
+      "release": "9.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "shadow-utils": {
+      "epoch": "2",
+      "version": "4.9",
+      "release": "8.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libtdb": {
+      "epoch": "0",
+      "version": "1.4.8",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "pciutils-libs": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "5.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "which": {
+      "epoch": "0",
+      "version": "2.21",
+      "release": "29.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "ethtool": {
+      "epoch": "2",
+      "version": "6.2",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "mpfr": {
+      "epoch": "0",
+      "version": "4.1.0",
+      "release": "7.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "chkconfig": {
+      "epoch": "0",
+      "version": "1.24",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libassuan": {
+      "epoch": "0",
+      "version": "2.5.5",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libbpf": {
+      "epoch": "2",
+      "version": "1.2.0",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "fuse-libs": {
+      "epoch": "0",
+      "version": "2.9.9",
+      "release": "15.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "jansson": {
+      "epoch": "0",
+      "version": "2.14",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libbasicobjects": {
+      "epoch": "0",
+      "version": "0.1.1",
+      "release": "53.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libcollection": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "53.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libdb": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "53.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "iproute": {
+      "epoch": "0",
+      "version": "6.2.0",
+      "release": "5.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libdhash": {
+      "epoch": "0",
+      "version": "0.5.0",
+      "release": "53.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libgomp": {
+      "epoch": "0",
+      "version": "11.4.1",
+      "release": "2.1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libref_array": {
+      "epoch": "0",
+      "version": "0.1.5",
+      "release": "53.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libseccomp": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libsigsegv": {
+      "epoch": "0",
+      "version": "2.13",
+      "release": "4.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "gawk": {
+      "epoch": "0",
+      "version": "5.1.0",
+      "release": "6.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libsss_idmap": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el9_3",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libtasn1": {
+      "epoch": "0",
+      "version": "4.16.0",
+      "release": "8.el9_1",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "p11-kit-trust": {
+      "epoch": "0",
+      "version": "0.24.1",
+      "release": "2.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libyaml": {
+      "epoch": "0",
+      "version": "0.2.5",
+      "release": "7.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "lzo": {
+      "epoch": "0",
+      "version": "2.10",
+      "release": "7.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "numactl-libs": {
+      "epoch": "0",
+      "version": "2.0.16",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "pcre": {
+      "epoch": "0",
+      "version": "8.44",
+      "release": "3.el9.3",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "grep": {
+      "epoch": "0",
+      "version": "3.6",
+      "release": "5.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "xz": {
+      "epoch": "0",
+      "version": "5.2.5",
+      "release": "8.el9_0",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "squashfs-tools": {
+      "epoch": "0",
+      "version": "4.4",
+      "release": "8.git1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libbytesize": {
+      "epoch": "0",
+      "version": "2.5",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libutempter": {
+      "epoch": "0",
+      "version": "1.2.1",
+      "release": "6.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "acl": {
+      "epoch": "0",
+      "version": "2.3.1",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "gettext-libs": {
+      "epoch": "0",
+      "version": "0.21",
+      "release": "8.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "gettext": {
+      "epoch": "0",
+      "version": "0.21",
+      "release": "8.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "tar": {
+      "epoch": "2",
+      "version": "1.34",
+      "release": "6.el9_1",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libpsl": {
+      "epoch": "0",
+      "version": "0.21.1",
+      "release": "5.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libselinux-utils": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libibverbs": {
+      "epoch": "0",
+      "version": "46.0",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libpcap": {
+      "epoch": "14",
+      "version": "1.10.0",
+      "release": "4.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libnl3-cli": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libteam": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "16.el9_1",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libcomps": {
+      "epoch": "0",
+      "version": "0.1.18",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libksba": {
+      "epoch": "0",
+      "version": "1.5.1",
+      "release": "6.el9_1",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "nss-softokn-freebl": {
+      "epoch": "0",
+      "version": "3.90.0",
+      "release": "3.el9_2",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "nss-softokn": {
+      "epoch": "0",
+      "version": "3.90.0",
+      "release": "3.el9_2",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "e2fsprogs-libs": {
+      "epoch": "0",
+      "version": "1.46.5",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libss": {
+      "epoch": "0",
+      "version": "1.46.5",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "groff-base": {
+      "epoch": "0",
+      "version": "1.22.4",
+      "release": "10.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "snappy": {
+      "epoch": "0",
+      "version": "1.1.8",
+      "release": "8.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "libxcrypt-compat": {
+      "epoch": "0",
+      "version": "4.4.18",
+      "release": "3.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "pigz": {
+      "epoch": "0",
+      "version": "2.5",
+      "release": "4.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "hostname": {
+      "epoch": "0",
+      "version": "3.23",
+      "release": "6.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "kernel-tools-libs": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "362.8.1.el9_3",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "less": {
+      "epoch": "0",
+      "version": "590",
+      "release": "2.el9_2",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "systemd-rpm-macros": {
+      "epoch": "0",
+      "version": "252",
+      "release": "18.el9",
+      "installdate": "1699429313",
+      "arch": "noarch"
+    },
+    "c-ares": {
+      "epoch": "0",
+      "version": "1.19.1",
+      "release": "1.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "cpio": {
+      "epoch": "0",
+      "version": "2.13",
+      "release": "16.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "diffutils": {
+      "epoch": "0",
+      "version": "3.7",
+      "release": "12.el9",
+      "installdate": "1699429313",
+      "arch": "x86_64"
+    },
+    "dosfstools": {
+      "epoch": "0",
+      "version": "4.2",
+      "release": "3.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "hdparm": {
+      "epoch": "0",
+      "version": "9.62",
+      "release": "2.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "inih": {
+      "epoch": "0",
+      "version": "49",
+      "release": "6.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libbrotli": {
+      "epoch": "0",
+      "version": "1.0.9",
+      "release": "6.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libcbor": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "5.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libdaemon": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "23.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libeconf": {
+      "epoch": "0",
+      "version": "0.4.1",
+      "release": "3.el9_2",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libndp": {
+      "epoch": "0",
+      "version": "1.8",
+      "release": "4.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libnfnetlink": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "21.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libnetfilter_conntrack": {
+      "epoch": "0",
+      "version": "1.0.9",
+      "release": "1.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "iptables-libs": {
+      "epoch": "0",
+      "version": "1.8.8",
+      "release": "6.el9_1",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libnghttp2": {
+      "epoch": "0",
+      "version": "1.43.0",
+      "release": "5.el9_3.1",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libpath_utils": {
+      "epoch": "0",
+      "version": "0.2.1",
+      "release": "53.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libini_config": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "53.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libpipeline": {
+      "epoch": "0",
+      "version": "1.5.3",
+      "release": "4.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libsmbios": {
+      "epoch": "0",
+      "version": "2.4.3",
+      "release": "4.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libsss_nss_idmap": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el9_3",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libsss_sudo": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el9_3",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libtraceevent": {
+      "epoch": "0",
+      "version": "1.5.3",
+      "release": "3.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libverto": {
+      "epoch": "0",
+      "version": "0.3.2",
+      "release": "3.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "lmdb-libs": {
+      "epoch": "0",
+      "version": "0.9.29",
+      "release": "3.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "nettle": {
+      "epoch": "0",
+      "version": "3.8",
+      "release": "3.el9_0",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "gnutls": {
+      "epoch": "0",
+      "version": "3.7.6",
+      "release": "23.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "npth": {
+      "epoch": "0",
+      "version": "1.6",
+      "release": "8.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "sg3_utils-libs": {
+      "epoch": "0",
+      "version": "1.47",
+      "release": "9.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "slang": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "11.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "newt": {
+      "epoch": "0",
+      "version": "0.52.21",
+      "release": "11.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "userspace-rcu": {
+      "epoch": "0",
+      "version": "0.12.1",
+      "release": "6.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "checkpolicy": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "1.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libestr": {
+      "epoch": "0",
+      "version": "0.1.11",
+      "release": "4.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libfastjson": {
+      "epoch": "0",
+      "version": "0.99.9",
+      "release": "5.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "libmaxminddb": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "3.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "ipcalc": {
+      "epoch": "0",
+      "version": "1.0.0",
+      "release": "5.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "linux-firmware-whence": {
+      "epoch": "0",
+      "version": "20230814",
+      "release": "140.el9_3",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "linux-firmware": {
+      "epoch": "0",
+      "version": "20230814",
+      "release": "140.el9_3",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "libssh-config": {
+      "epoch": "0",
+      "version": "0.10.4",
+      "release": "11.el9",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "kbd-misc": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el9",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "kbd-legacy": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el9",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "fonts-filesystem": {
+      "epoch": "1",
+      "version": "2.0.5",
+      "release": "7.el9.1",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "dejavu-sans-fonts": {
+      "epoch": "0",
+      "version": "2.37",
+      "release": "18.el9",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "langpacks-core-font-en": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "16.el9",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "langpacks-core-en": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "16.el9",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "dhcp-common": {
+      "epoch": "12",
+      "version": "4.4.2",
+      "release": "19.b1.el9",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "coreutils-common": {
+      "epoch": "0",
+      "version": "8.32",
+      "release": "34.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "openssl-libs": {
+      "epoch": "1",
+      "version": "3.0.7",
+      "release": "24.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "coreutils": {
+      "epoch": "0",
+      "version": "8.32",
+      "release": "34.el9",
+      "installdate": "1699429314",
+      "arch": "x86_64"
+    },
+    "ca-certificates": {
+      "epoch": "0",
+      "version": "2023.2.60_v7.0.306",
+      "release": "90.1.el9_2",
+      "installdate": "1699429314",
+      "arch": "noarch"
+    },
+    "systemd-libs": {
+      "epoch": "0",
+      "version": "252",
+      "release": "18.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libblkid": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "15.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "kmod-libs": {
+      "epoch": "0",
+      "version": "28",
+      "release": "9.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "krb5-libs": {
+      "epoch": "0",
+      "version": "1.21.1",
+      "release": "1.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "dbus-libs": {
+      "epoch": "1",
+      "version": "1.12.20",
+      "release": "8.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libmount": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "15.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "glib2": {
+      "epoch": "0",
+      "version": "2.68.4",
+      "release": "11.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "json-glib": {
+      "epoch": "0",
+      "version": "1.6.6",
+      "release": "1.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "polkit-libs": {
+      "epoch": "0",
+      "version": "0.117",
+      "release": "11.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "kmod": {
+      "epoch": "0",
+      "version": "28",
+      "release": "9.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "NetworkManager-libnm": {
+      "epoch": "1",
+      "version": "1.44.0",
+      "release": "3.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "util-linux-core": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "15.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libfdisk": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "15.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "procps-ng": {
+      "epoch": "0",
+      "version": "3.3.17",
+      "release": "13.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "gzip": {
+      "epoch": "0",
+      "version": "1.12",
+      "release": "1.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "cracklib": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "27.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libgudev": {
+      "epoch": "0",
+      "version": "237",
+      "release": "1.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "shared-mime-info": {
+      "epoch": "0",
+      "version": "2.1",
+      "release": "5.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "e2fsprogs": {
+      "epoch": "0",
+      "version": "1.46.5",
+      "release": "3.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libusbx": {
+      "epoch": "0",
+      "version": "1.0.26",
+      "release": "1.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "openssl": {
+      "epoch": "1",
+      "version": "3.0.7",
+      "release": "24.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libarchive": {
+      "epoch": "0",
+      "version": "3.5.3",
+      "release": "4.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libgusb": {
+      "epoch": "0",
+      "version": "0.3.8",
+      "release": "2.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libxmlb": {
+      "epoch": "0",
+      "version": "0.3.10",
+      "release": "1.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "cracklib-dicts": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "27.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "libpwquality": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "8.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "pam": {
+      "epoch": "0",
+      "version": "1.5.1",
+      "release": "15.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "util-linux": {
+      "epoch": "0",
+      "version": "2.37.4",
+      "release": "15.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "dbus": {
+      "epoch": "1",
+      "version": "1.12.20",
+      "release": "8.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "systemd-pam": {
+      "epoch": "0",
+      "version": "252",
+      "release": "18.el9",
+      "installdate": "1699429315",
+      "arch": "x86_64"
+    },
+    "systemd": {
+      "epoch": "0",
+      "version": "252",
+      "release": "18.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "dbus-common": {
+      "epoch": "1",
+      "version": "1.12.20",
+      "release": "8.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "dbus-broker": {
+      "epoch": "0",
+      "version": "28",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "grub2-common": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "70.el9_3.1",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "polkit": {
+      "epoch": "0",
+      "version": "0.117",
+      "release": "11.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "polkit-pkla-compat": {
+      "epoch": "0",
+      "version": "0.1",
+      "release": "21.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "cronie-anacron": {
+      "epoch": "0",
+      "version": "1.5.7",
+      "release": "8.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "cronie": {
+      "epoch": "0",
+      "version": "1.5.7",
+      "release": "8.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "crontabs": {
+      "epoch": "0",
+      "version": "1.11",
+      "release": "27.20190603git.el9_0",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "initscripts-service": {
+      "epoch": "0",
+      "version": "10.11.5",
+      "release": "1.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "iputils": {
+      "epoch": "0",
+      "version": "20210202",
+      "release": "9.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "dhcp-client": {
+      "epoch": "12",
+      "version": "4.4.2",
+      "release": "19.b1.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "openssh": {
+      "epoch": "0",
+      "version": "8.7p1",
+      "release": "34.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "virt-what": {
+      "epoch": "0",
+      "version": "1.25",
+      "release": "5.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "grub2-pc-modules": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "70.el9_3.1",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "authselect-libs": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "2.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "device-mapper-libs": {
+      "epoch": "9",
+      "version": "1.02.195",
+      "release": "3.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "device-mapper": {
+      "epoch": "9",
+      "version": "1.02.195",
+      "release": "3.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "grub2-tools-minimal": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "70.el9_3.1",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "cryptsetup-libs": {
+      "epoch": "0",
+      "version": "2.6.0",
+      "release": "3.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "parted": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "2.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libblockdev-utils": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "xfsprogs": {
+      "epoch": "0",
+      "version": "5.19.0",
+      "release": "4.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libblockdev": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libblockdev-fs": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libblockdev-loop": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libblockdev-part": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libblockdev-swap": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "kpartx": {
+      "epoch": "0",
+      "version": "0.8.7",
+      "release": "22.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "elfutils-default-yama-scope": {
+      "epoch": "0",
+      "version": "0.189",
+      "release": "3.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "elfutils-libs": {
+      "epoch": "0",
+      "version": "0.189",
+      "release": "3.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libkcapi": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "3.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libkcapi-hmaccalc": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "3.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "logrotate": {
+      "epoch": "0",
+      "version": "3.18.0",
+      "release": "8.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "mdadm": {
+      "epoch": "0",
+      "version": "4.2",
+      "release": "9.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libblockdev-mdraid": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "oddjob": {
+      "epoch": "0",
+      "version": "0.34.7",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "kbd": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "sssd-client": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el9_3",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "librhsm": {
+      "epoch": "0",
+      "version": "0.0.3",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "gobject-introspection": {
+      "epoch": "0",
+      "version": "1.68.0",
+      "release": "11.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "initscripts-rename-device": {
+      "epoch": "0",
+      "version": "10.11.5",
+      "release": "1.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "initscripts": {
+      "epoch": "0",
+      "version": "10.11.5",
+      "release": "1.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libgcab1": {
+      "epoch": "0",
+      "version": "1.4",
+      "release": "6.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libudisks2": {
+      "epoch": "0",
+      "version": "2.9.4",
+      "release": "9.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "dbus-tools": {
+      "epoch": "1",
+      "version": "1.12.20",
+      "release": "8.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "oddjob-mkhomedir": {
+      "epoch": "0",
+      "version": "0.34.7",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "authselect": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "2.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "cyrus-sasl-lib": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "21.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libssh": {
+      "epoch": "0",
+      "version": "0.10.4",
+      "release": "11.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "pciutils": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "5.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "libatasmart": {
+      "epoch": "0",
+      "version": "0.19",
+      "release": "22.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "python3-pip-wheel": {
+      "epoch": "0",
+      "version": "21.2.3",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "python-unversioned-command": {
+      "epoch": "0",
+      "version": "3.9.18",
+      "release": "1.el9_3",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "python3": {
+      "epoch": "0",
+      "version": "3.9.18",
+      "release": "1.el9_3",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "python3-libs": {
+      "epoch": "0",
+      "version": "3.9.18",
+      "release": "1.el9_3",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "python3-setuptools": {
+      "epoch": "0",
+      "version": "53.0.0",
+      "release": "12.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "python3-six": {
+      "epoch": "0",
+      "version": "1.15.0",
+      "release": "9.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "python3-dbus": {
+      "epoch": "0",
+      "version": "1.2.18",
+      "release": "2.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "python3-dateutil": {
+      "epoch": "1",
+      "version": "2.8.1",
+      "release": "7.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "python3-gobject-base-noarch": {
+      "epoch": "0",
+      "version": "3.40.1",
+      "release": "6.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "python3-gobject-base": {
+      "epoch": "0",
+      "version": "3.40.1",
+      "release": "6.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "python3-libselinux": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "1.el9",
+      "installdate": "1699429316",
+      "arch": "x86_64"
+    },
+    "python3-iniparse": {
+      "epoch": "0",
+      "version": "0.4",
+      "release": "45.el9",
+      "installdate": "1699429316",
+      "arch": "noarch"
+    },
+    "python3-distro": {
+      "epoch": "0",
+      "version": "1.5.0",
+      "release": "7.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-idna": {
+      "epoch": "0",
+      "version": "2.10",
+      "release": "7.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-pyyaml": {
+      "epoch": "0",
+      "version": "5.4.1",
+      "release": "6.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-libsemanage": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "2.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-linux-procfs": {
+      "epoch": "0",
+      "version": "0.7.1",
+      "release": "1.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-pyudev": {
+      "epoch": "0",
+      "version": "0.22.0",
+      "release": "6.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-configobj": {
+      "epoch": "0",
+      "version": "5.0.6",
+      "release": "25.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-inotify": {
+      "epoch": "0",
+      "version": "0.9.6",
+      "release": "25.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-setools": {
+      "epoch": "0",
+      "version": "4.4.3",
+      "release": "1.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-libcomps": {
+      "epoch": "0",
+      "version": "0.1.18",
+      "release": "1.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "kernel-tools": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "362.8.1.el9_3",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-chardet": {
+      "epoch": "0",
+      "version": "4.0.0",
+      "release": "5.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-decorator": {
+      "epoch": "0",
+      "version": "4.4.2",
+      "release": "6.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-perf": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "362.8.1.el9_3",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-pysocks": {
+      "epoch": "0",
+      "version": "1.7.1",
+      "release": "12.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-urllib3": {
+      "epoch": "0",
+      "version": "1.26.5",
+      "release": "3.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-requests": {
+      "epoch": "0",
+      "version": "2.25.1",
+      "release": "7.el9_2",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-cloud-what": {
+      "epoch": "0",
+      "version": "1.29.38",
+      "release": "1.el9_3",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-systemd": {
+      "epoch": "0",
+      "version": "234",
+      "release": "18.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "teamd": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "16.el9_1",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-attrs": {
+      "epoch": "0",
+      "version": "20.3.0",
+      "release": "7.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-audit": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "104.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-file-magic": {
+      "epoch": "0",
+      "version": "5.39",
+      "release": "14.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-jsonpointer": {
+      "epoch": "0",
+      "version": "2.0",
+      "release": "4.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-jsonpatch": {
+      "epoch": "0",
+      "version": "1.21",
+      "release": "16.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-markupsafe": {
+      "epoch": "0",
+      "version": "1.1.1",
+      "release": "12.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-netifaces": {
+      "epoch": "0",
+      "version": "0.10.6",
+      "release": "15.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-oauthlib": {
+      "epoch": "0",
+      "version": "3.1.1",
+      "release": "5.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-prettytable": {
+      "epoch": "0",
+      "version": "0.7.2",
+      "release": "27.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-pyrsistent": {
+      "epoch": "0",
+      "version": "0.17.3",
+      "release": "8.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "python3-jsonschema": {
+      "epoch": "0",
+      "version": "3.2.0",
+      "release": "13.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-pyserial": {
+      "epoch": "0",
+      "version": "3.4",
+      "release": "12.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-pytz": {
+      "epoch": "0",
+      "version": "2021.1",
+      "release": "5.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-babel": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "2.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "python3-jinja2": {
+      "epoch": "0",
+      "version": "2.11.3",
+      "release": "4.el9",
+      "installdate": "1699429317",
+      "arch": "noarch"
+    },
+    "libevent": {
+      "epoch": "0",
+      "version": "2.1.12",
+      "release": "6.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "openldap": {
+      "epoch": "0",
+      "version": "2.6.3",
+      "release": "1.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "libcurl": {
+      "epoch": "0",
+      "version": "7.76.1",
+      "release": "26.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "gnupg2": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "4.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "gpgme": {
+      "epoch": "0",
+      "version": "1.15.1",
+      "release": "6.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "librepo": {
+      "epoch": "0",
+      "version": "1.14.5",
+      "release": "1.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "tpm2-tss": {
+      "epoch": "0",
+      "version": "3.2.2",
+      "release": "2.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "systemd-udev": {
+      "epoch": "0",
+      "version": "252",
+      "release": "18.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "dracut": {
+      "epoch": "0",
+      "version": "057",
+      "release": "44.git20230822.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "NetworkManager": {
+      "epoch": "1",
+      "version": "1.44.0",
+      "release": "3.el9",
+      "installdate": "1699429317",
+      "arch": "x86_64"
+    },
+    "kernel-modules-core": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "362.8.1.el9_3",
+      "installdate": "1699429318",
+      "arch": "x86_64"
+    },
+    "kernel-core": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "362.8.1.el9_3",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "elfutils-debuginfod-client": {
+      "epoch": "0",
+      "version": "0.189",
+      "release": "3.el9",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "binutils-gold": {
+      "epoch": "0",
+      "version": "2.35.2",
+      "release": "42.el9",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "binutils": {
+      "epoch": "0",
+      "version": "2.35.2",
+      "release": "42.el9",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "libldb": {
+      "epoch": "0",
+      "version": "2.7.2",
+      "release": "2.el9",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "libuser": {
+      "epoch": "0",
+      "version": "0.63",
+      "release": "13.el9",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "passwd": {
+      "epoch": "0",
+      "version": "0.80",
+      "release": "12.el9",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "usermode": {
+      "epoch": "0",
+      "version": "1.114",
+      "release": "4.el9",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "kernel-modules": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "362.8.1.el9_3",
+      "installdate": "1699429319",
+      "arch": "x86_64"
+    },
+    "dracut-network": {
+      "epoch": "0",
+      "version": "057",
+      "release": "44.git20230822.el9",
+      "installdate": "1699429323",
+      "arch": "x86_64"
+    },
+    "dracut-squash": {
+      "epoch": "0",
+      "version": "057",
+      "release": "44.git20230822.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "libfido2": {
+      "epoch": "0",
+      "version": "1.13.0",
+      "release": "1.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "os-prober": {
+      "epoch": "0",
+      "version": "1.77",
+      "release": "10.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "grub2-tools": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "70.el9_3.1",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "flashrom": {
+      "epoch": "0",
+      "version": "1.2",
+      "release": "10.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "ima-evm-utils": {
+      "epoch": "0",
+      "version": "1.4",
+      "release": "4.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "python3-librepo": {
+      "epoch": "0",
+      "version": "1.14.5",
+      "release": "1.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "libjcat": {
+      "epoch": "0",
+      "version": "0.1.6",
+      "release": "3.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "python3-gpg": {
+      "epoch": "0",
+      "version": "1.15.1",
+      "release": "6.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "curl": {
+      "epoch": "0",
+      "version": "7.76.1",
+      "release": "26.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "rpm": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "25.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "rpm-libs": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "25.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "policycoreutils": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "2.el9",
+      "installdate": "1699429324",
+      "arch": "x86_64"
+    },
+    "selinux-policy": {
+      "epoch": "0",
+      "version": "38.1.23",
+      "release": "1.el9",
+      "installdate": "1699429324",
+      "arch": "noarch"
+    },
+    "selinux-policy-targeted": {
+      "epoch": "0",
+      "version": "38.1.23",
+      "release": "1.el9",
+      "installdate": "1699429324",
+      "arch": "noarch"
+    },
+    "python3-policycoreutils": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "2.el9",
+      "installdate": "1699429330",
+      "arch": "noarch"
+    },
+    "policycoreutils-python-utils": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "2.el9",
+      "installdate": "1699429331",
+      "arch": "noarch"
+    },
+    "insights-client": {
+      "epoch": "0",
+      "version": "3.2.2",
+      "release": "1.el9_3",
+      "installdate": "1699429331",
+      "arch": "noarch"
+    },
+    "grubby": {
+      "epoch": "0",
+      "version": "8.40",
+      "release": "63.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "libmodulemd": {
+      "epoch": "0",
+      "version": "2.13.0",
+      "release": "2.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "libsolv": {
+      "epoch": "0",
+      "version": "0.7.24",
+      "release": "2.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "libdnf": {
+      "epoch": "0",
+      "version": "0.69.0",
+      "release": "6.el9_3",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "python3-libdnf": {
+      "epoch": "0",
+      "version": "0.69.0",
+      "release": "6.el9_3",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "python3-hawkey": {
+      "epoch": "0",
+      "version": "0.69.0",
+      "release": "6.el9_3",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "libdnf-plugin-subscription-manager": {
+      "epoch": "0",
+      "version": "1.29.38",
+      "release": "1.el9_3",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "amazon-libdnf-plugin": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "1.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "crypto-policies-scripts": {
+      "epoch": "0",
+      "version": "20230731",
+      "release": "1.git94f0e2c.el9_3.1",
+      "installdate": "1699429331",
+      "arch": "noarch"
+    },
+    "nss-sysinit": {
+      "epoch": "0",
+      "version": "3.90.0",
+      "release": "3.el9_2",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "nss": {
+      "epoch": "0",
+      "version": "3.90.0",
+      "release": "3.el9_2",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "volume_key-libs": {
+      "epoch": "0",
+      "version": "0.3.12",
+      "release": "15.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "libblockdev-crypto": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "7.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "udisks2": {
+      "epoch": "0",
+      "version": "2.9.4",
+      "release": "9.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "fwupd-plugin-flashrom": {
+      "epoch": "0",
+      "version": "1.8.16",
+      "release": "1.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "fwupd": {
+      "epoch": "0",
+      "version": "1.8.16",
+      "release": "1.el9",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "rhc": {
+      "epoch": "1",
+      "version": "0.2.4",
+      "release": "3.el9_3",
+      "installdate": "1699429331",
+      "arch": "x86_64"
+    },
+    "rpm-build-libs": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "25.el9",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "rpm-sign-libs": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "25.el9",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "python3-rpm": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "25.el9",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "python3-subscription-manager-rhsm": {
+      "epoch": "0",
+      "version": "1.29.38",
+      "release": "1.el9_3",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-systemd-inhibit": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "25.el9",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "python3-dnf": {
+      "epoch": "0",
+      "version": "4.14.0",
+      "release": "8.el9",
+      "installdate": "1699429338",
+      "arch": "noarch"
+    },
+    "dnf": {
+      "epoch": "0",
+      "version": "4.14.0",
+      "release": "8.el9",
+      "installdate": "1699429338",
+      "arch": "noarch"
+    },
+    "python3-dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "11.el9_3",
+      "installdate": "1699429338",
+      "arch": "noarch"
+    },
+    "subscription-manager": {
+      "epoch": "0",
+      "version": "1.29.38",
+      "release": "1.el9_3",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "11.el9_3",
+      "installdate": "1699429338",
+      "arch": "noarch"
+    },
+    "rsyslog-logrotate": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "117.el9",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "rsyslog": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "117.el9",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "libsss_certmap": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el9_3",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "sssd-common": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el9_3",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "mokutil": {
+      "epoch": "2",
+      "version": "0.6.0",
+      "release": "4.el9",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "shim-x64": {
+      "epoch": "0",
+      "version": "15.6",
+      "release": "1.el9",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "sssd-kcm": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el9_3",
+      "installdate": "1699429338",
+      "arch": "x86_64"
+    },
+    "yum-utils": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "11.el9_3",
+      "installdate": "1699429338",
+      "arch": "noarch"
+    },
+    "tuned": {
+      "epoch": "0",
+      "version": "2.21.0",
+      "release": "1.el9_3",
+      "installdate": "1699429338",
+      "arch": "noarch"
+    },
+    "redhat-cloud-client-configuration": {
+      "epoch": "0",
+      "version": "1",
+      "release": "11.el9",
+      "installdate": "1699429338",
+      "arch": "noarch"
+    },
+    "yum": {
+      "epoch": "0",
+      "version": "4.14.0",
+      "release": "8.el9",
+      "installdate": "1699429339",
+      "arch": "noarch"
+    },
+    "rh-amazon-rhui-client": {
+      "epoch": "0",
+      "version": "4.0.13",
+      "release": "1.el9",
+      "installdate": "1699429339",
+      "arch": "noarch"
+    },
+    "kexec-tools": {
+      "epoch": "0",
+      "version": "2.0.26",
+      "release": "8.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "cloud-init": {
+      "epoch": "0",
+      "version": "23.1.1",
+      "release": "11.el9",
+      "installdate": "1699429339",
+      "arch": "noarch"
+    },
+    "rpm-plugin-selinux": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "25.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-audit": {
+      "epoch": "0",
+      "version": "4.16.1.3",
+      "release": "25.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "grub2-efi-x64": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "70.el9_3.1",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "grub2-pc": {
+      "epoch": "1",
+      "version": "2.06",
+      "release": "70.el9_3.1",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "openssh-clients": {
+      "epoch": "0",
+      "version": "8.7p1",
+      "release": "34.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "kernel": {
+      "epoch": "0",
+      "version": "5.14.0",
+      "release": "362.8.1.el9_3",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "NetworkManager-team": {
+      "epoch": "1",
+      "version": "1.44.0",
+      "release": "3.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "NetworkManager-tui": {
+      "epoch": "1",
+      "version": "1.44.0",
+      "release": "3.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "NetworkManager-cloud-setup": {
+      "epoch": "1",
+      "version": "1.44.0",
+      "release": "3.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "dracut-config-generic": {
+      "epoch": "0",
+      "version": "057",
+      "release": "44.git20230822.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "sudo": {
+      "epoch": "0",
+      "version": "1.9.5p2",
+      "release": "9.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "authselect-compat": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "2.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "openssh-server": {
+      "epoch": "0",
+      "version": "8.7p1",
+      "release": "34.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "audit": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "104.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "chrony": {
+      "epoch": "0",
+      "version": "4.3",
+      "release": "1.el9",
+      "installdate": "1699429339",
+      "arch": "x86_64"
+    },
+    "microcode_ctl": {
+      "epoch": "4",
+      "version": "20230808",
+      "release": "2.el9",
+      "installdate": "1699429339",
+      "arch": "noarch"
+    },
+    "cloud-utils-growpart": {
+      "epoch": "0",
+      "version": "0.33",
+      "release": "1.el9",
+      "installdate": "1699429340",
+      "arch": "x86_64"
+    },
+    "man-db": {
+      "epoch": "0",
+      "version": "2.9.3",
+      "release": "7.el9",
+      "installdate": "1699429340",
+      "arch": "x86_64"
+    },
+    "irqbalance": {
+      "epoch": "2",
+      "version": "1.9.2",
+      "release": "3.el9",
+      "installdate": "1699429340",
+      "arch": "x86_64"
+    },
+    "prefixdevname": {
+      "epoch": "0",
+      "version": "0.1.0",
+      "release": "8.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "rsync": {
+      "epoch": "0",
+      "version": "3.2.3",
+      "release": "19.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "langpacks-en": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "16.el9",
+      "installdate": "1699429341",
+      "arch": "noarch"
+    },
+    "sg3_utils": {
+      "epoch": "0",
+      "version": "1.47",
+      "release": "9.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "iproute-tc": {
+      "epoch": "0",
+      "version": "6.2.0",
+      "release": "5.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "vim-minimal": {
+      "epoch": "2",
+      "version": "8.2.2637",
+      "release": "20.el9_1",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "efibootmgr": {
+      "epoch": "0",
+      "version": "16",
+      "release": "12.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "lshw": {
+      "epoch": "0",
+      "version": "B.02.19.2",
+      "release": "10.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "ncurses": {
+      "epoch": "0",
+      "version": "6.2",
+      "release": "10.20210508.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "libsysfs": {
+      "epoch": "0",
+      "version": "2.1.1",
+      "release": "10.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "lsscsi": {
+      "epoch": "0",
+      "version": "0.32",
+      "release": "6.el9",
+      "installdate": "1699429341",
+      "arch": "x86_64"
+    },
+    "rootfiles": {
+      "epoch": "0",
+      "version": "8.1",
+      "release": "31.el9",
+      "installdate": "1699429341",
+      "arch": "noarch"
+    },
+    "gpg-pubkey": {
+      "epoch": "0",
+      "version": "f21541eb",
+      "release": "4a5233e7",
+      "installdate": "1699972225",
+      "arch": "(none)",
+      "versions": [
+        {
+          "epoch": "0",
+          "version": "fd431d51",
+          "release": "4ae0493b",
+          "installdate": "1699972225",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "5a6340b3",
+          "release": "6229229e",
+          "installdate": "1699972225",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "f21541eb",
+          "release": "4a5233e7",
+          "installdate": "1699972225",
+          "arch": "(none)"
+        }
+      ]
+    },
+    "chef": {
+      "epoch": "0",
+      "version": "17.9.26",
+      "release": "1.el8",
+      "installdate": "1699972390",
+      "arch": "x86_64"
+    }
+  },
+  "platform": "redhat",
+  "platform_family": "rhel",
+  "platform_version": "9.3",
+  "root_group": "root",
+  "shard_seed": 160749321,
+  "shells": [
+    "/bin/sh",
+    "/bin/bash",
+    "/usr/bin/sh",
+    "/usr/bin/bash"
+  ],
+  "time": {
+    "timezone": "GMT"
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "virtualization": {
+    "systems": {}
+  }
+}

--- a/platforms.json
+++ b/platforms.json
@@ -219,6 +219,10 @@
     "8": {
       "deprecated": false,
       "path": "lib/fauxhai/platforms/redhat/8.json"
+    },
+    "9": {
+      "deprecated": false,
+      "path": "lib/fauxhai/platforms/redhat/9.json"
     }
   },
   "rocky": {


### PR DESCRIPTION
Added RedHat 9 Fauxhai data

## Description
RedHat 9 FauxHai data was missing from the platforms

## Related Issue
#20 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
