### PR TITLE
Add Ubuntu 24.04

### DIFF
--- a/lib/fauxhai/platforms/ubuntu/24.04.json
+++ b/lib/fauxhai/platforms/ubuntu/24.04.json
@@ -1,0 +1,4498 @@
+{
+  "block_device": {
+    "dm-0": {
+      "size": "24109056",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop0": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop1": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop2": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop3": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop4": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop5": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop6": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "loop7": {
+      "size": "0",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "sr0": {
+      "size": "4",
+      "removable": "1",
+      "model": "QEMU DVD-ROM",
+      "rev": "2.5+",
+      "state": "running",
+      "timeout": "30",
+      "vendor": "QEMU",
+      "queue_depth": "1",
+      "rotational": "1",
+      "physical_block_size": "2048",
+      "logical_block_size": "2048"
+    },
+    "vda": {
+      "size": "52428800",
+      "removable": "0",
+      "vendor": "0x1af4",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    }
+  },
+  "chef_packages": {
+    "ohai": {
+      "version": "18.1.3",
+      "ohai_root": "/usr/share/rubygems-integration/all/gems/ohai-18.1.3/lib/ohai"
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "lo": {
+          "tx": {
+            "queuelen": "1",
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "carrier": 0,
+            "collisions": 0
+          },
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0
+          }
+        },
+        "eth0": {
+          "rx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": 0,
+            "packets": 0,
+            "errors": 0,
+            "drop": 0,
+            "overrun": 0,
+            "collisions": 0,
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "current_user": "fauxhai",
+  "dmi": {
+    "dmidecode_version": "3.5",
+    "smbios_version": "2.8",
+    "structures": {
+      "count": "11",
+      "size": "460"
+    },
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "SeaBIOS",
+          "Version": "1.15.0-1",
+          "Release Date": "04/01/2014",
+          "Address": "0xE8000",
+          "Runtime Size": "96 kB",
+          "ROM Size": "64 kB",
+          "Characteristics": {
+            "Targeted content distribution is supported": null
+          },
+          "BIOS Revision": "0.0"
+        }
+      ],
+      "vendor": "SeaBIOS",
+      "version": "1.15.0-1",
+      "release_date": "04/01/2014",
+      "address": "0xE8000",
+      "runtime_size": "96 kB",
+      "rom_size": "64 kB",
+      "bios_revision": "0.0"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0100",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "QEMU",
+          "Product Name": "Standard PC (Q35 + ICH9, 2009)",
+          "Version": "pc-q35-6.2",
+          "Serial Number": "Not Specified",
+          "UUID": "ee2b5bdc-7b04-4f2c-891b-3c075acebf84",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Not Specified"
+        }
+      ],
+      "manufacturer": "QEMU",
+      "product_name": "Standard PC (Q35 + ICH9, 2009)",
+      "version": "pc-q35-6.2",
+      "serial_number": "Not Specified",
+      "uuid": "ee2b5bdc-7b04-4f2c-891b-3c075acebf84",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Not Specified"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0300",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "QEMU",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "pc-q35-6.2",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "Unknown",
+          "OEM Information": "0x00000000",
+          "Height": "Unspecified",
+          "Number Of Power Cords": "Unspecified",
+          "Contained Elements": "0",
+          "SKU Number": "Not Specified"
+        }
+      ],
+      "manufacturer": "QEMU",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "pc-q35-6.2",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "Unknown",
+      "oem_information": "0x00000000",
+      "height": "Unspecified",
+      "number_of_power_cords": "Unspecified",
+      "contained_elements": "0",
+      "sku_number": "Not Specified"
+    },
+    "processor": {
+      "all_records": [
+        {
+          "record_id": "0x0400",
+          "size": "4",
+          "application_identifier": "Processor Information",
+          "Socket Designation": "CPU 0",
+          "Type": "Central Processor",
+          "Family": "Other",
+          "Manufacturer": "QEMU",
+          "ID": "C1 06 08 00 FF FB 8B 0F",
+          "Version": "pc-q35-6.2",
+          "Voltage": "Unknown",
+          "External Clock": "Unknown",
+          "Max Speed": "2000 MHz",
+          "Current Speed": "2000 MHz",
+          "Status": "Populated, Enabled",
+          "Upgrade": "Other",
+          "L1 Cache Handle": "Not Provided",
+          "L2 Cache Handle": "Not Provided",
+          "L3 Cache Handle": "Not Provided",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Part Number": "Not Specified",
+          "Core Count": "1",
+          "Core Enabled": "1",
+          "Thread Count": "1",
+          "Characteristics": "None"
+        },
+        {
+          "record_id": "0x0401",
+          "size": "4",
+          "application_identifier": "Processor Information",
+          "Socket Designation": "CPU 1",
+          "Type": "Central Processor",
+          "Family": "Other",
+          "Manufacturer": "QEMU",
+          "ID": "C1 06 08 00 FF FB 8B 0F",
+          "Version": "pc-q35-6.2",
+          "Voltage": "Unknown",
+          "External Clock": "Unknown",
+          "Max Speed": "2000 MHz",
+          "Current Speed": "2000 MHz",
+          "Status": "Populated, Enabled",
+          "Upgrade": "Other",
+          "L1 Cache Handle": "Not Provided",
+          "L2 Cache Handle": "Not Provided",
+          "L3 Cache Handle": "Not Provided",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Part Number": "Not Specified",
+          "Core Count": "1",
+          "Core Enabled": "1",
+          "Thread Count": "1",
+          "Characteristics": "None"
+        }
+      ],
+      "type": "Central Processor",
+      "family": "Other",
+      "manufacturer": "QEMU",
+      "id": "C1 06 08 00 FF FB 8B 0F",
+      "version": "pc-q35-6.2",
+      "voltage": "Unknown",
+      "external_clock": "Unknown",
+      "max_speed": "2000 MHz",
+      "current_speed": "2000 MHz",
+      "status": "Populated, Enabled",
+      "upgrade": "Other",
+      "l1_cache_handle": "Not Provided",
+      "l2_cache_handle": "Not Provided",
+      "l3_cache_handle": "Not Provided",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "part_number": "Not Specified",
+      "core_count": "1",
+      "core_enabled": "1",
+      "thread_count": "1",
+      "characteristics": "None"
+    }
+  },
+  "domain": "local",
+  "filesystem": {
+    "by_device": {
+      "tmpfs": {
+        "kb_size": "401004",
+        "kb_used": "12",
+        "kb_available": "400992",
+        "percent_used": "1%",
+        "total_inodes": "100251",
+        "inodes_used": "32",
+        "inodes_available": "100219",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=401004k",
+          "nr_inodes=100251",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "mounts": [
+          "/run",
+          "/dev/shm",
+          "/run/lock",
+          "/run/user/1000"
+        ]
+      },
+      "/dev/mapper/ubuntu--vg-ubuntu--lv": {
+        "kb_size": "11758760",
+        "kb_used": "4550876",
+        "kb_available": "6588776",
+        "percent_used": "41%",
+        "total_inodes": "753664",
+        "inodes_used": "92415",
+        "inodes_available": "661249",
+        "inodes_percent_used": "13%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "36dcbcdf-b43a-4ae3-931e-bf2a0ce14e06",
+        "mounts": [
+          "/"
+        ]
+      },
+      "/dev/vda2": {
+        "kb_size": "1992552",
+        "kb_used": "171460",
+        "kb_available": "1699852",
+        "percent_used": "10%",
+        "total_inodes": "131072",
+        "inodes_used": "317",
+        "inodes_available": "130755",
+        "inodes_percent_used": "1%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "0ef115d9-01b7-4521-8205-c3d8073cf019",
+        "mounts": [
+          "/boot"
+        ]
+      },
+      "sysfs": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys"
+        ]
+      },
+      "proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc"
+        ]
+      },
+      "udev": {
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=1931232k",
+          "nr_inodes=482808",
+          "mode=755",
+          "inode64"
+        ],
+        "mounts": [
+          "/dev"
+        ]
+      },
+      "devpts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "mounts": [
+          "/dev/pts"
+        ]
+      },
+      "securityfs": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/security"
+        ]
+      },
+      "cgroup2": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup"
+        ]
+      },
+      "pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/pstore"
+        ]
+      },
+      "bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/sys/fs/bpf"
+        ]
+      },
+      "systemd-1": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=32",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=5531"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/dev/mqueue"
+        ]
+      },
+      "hugetlbfs": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "mounts": [
+          "/dev/hugepages"
+        ]
+      },
+      "debugfs": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/debug"
+        ]
+      },
+      "tracefs": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/tracing"
+        ]
+      },
+      "configfs": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/config"
+        ]
+      },
+      "fusectl": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/fuse/connections"
+        ]
+      },
+      "binfmt_misc": {
+        "fs_type": "binfmt_misc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "/dev/sr0": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/vda": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/vda1": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/vda3": {
+        "fs_type": "LVM2_member",
+        "uuid": "F5vQHj-prYV-QT7X-2w4Y-QwfL-MWe0-kHbdxr",
+        "mounts": [
+
+        ]
+      }
+    },
+    "by_mountpoint": {
+      "/run": {
+        "kb_size": "401008",
+        "kb_used": "1160",
+        "kb_available": "399848",
+        "percent_used": "1%",
+        "total_inodes": "501256",
+        "inodes_used": "782",
+        "inodes_available": "500474",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=401008k",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/": {
+        "kb_size": "11758760",
+        "kb_used": "4550876",
+        "kb_available": "6588776",
+        "percent_used": "41%",
+        "total_inodes": "753664",
+        "inodes_used": "92415",
+        "inodes_available": "661249",
+        "inodes_percent_used": "13%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "36dcbcdf-b43a-4ae3-931e-bf2a0ce14e06",
+        "devices": [
+          "/dev/mapper/ubuntu--vg-ubuntu--lv"
+        ]
+      },
+      "/dev/shm": {
+        "kb_size": "2005024",
+        "kb_used": "0",
+        "kb_available": "2005024",
+        "percent_used": "0%",
+        "total_inodes": "501256",
+        "inodes_used": "1",
+        "inodes_available": "501255",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/run/lock": {
+        "kb_size": "5120",
+        "kb_used": "0",
+        "kb_available": "5120",
+        "percent_used": "0%",
+        "total_inodes": "501256",
+        "inodes_used": "3",
+        "inodes_available": "501253",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/boot": {
+        "kb_size": "1992552",
+        "kb_used": "171460",
+        "kb_available": "1699852",
+        "percent_used": "10%",
+        "total_inodes": "131072",
+        "inodes_used": "317",
+        "inodes_available": "130755",
+        "inodes_percent_used": "1%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "0ef115d9-01b7-4521-8205-c3d8073cf019",
+        "devices": [
+          "/dev/vda2"
+        ]
+      },
+      "/run/user/1000": {
+        "kb_size": "401004",
+        "kb_used": "12",
+        "kb_available": "400992",
+        "percent_used": "1%",
+        "total_inodes": "100251",
+        "inodes_used": "32",
+        "inodes_available": "100219",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=401004k",
+          "nr_inodes=100251",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/sys": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "sysfs"
+        ]
+      },
+      "/proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "proc"
+        ]
+      },
+      "/dev": {
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=1931232k",
+          "nr_inodes=482808",
+          "mode=755",
+          "inode64"
+        ],
+        "devices": [
+          "udev"
+        ]
+      },
+      "/dev/pts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "devices": [
+          "devpts"
+        ]
+      },
+      "/sys/kernel/security": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "securityfs"
+        ]
+      },
+      "/sys/fs/cgroup": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ],
+        "devices": [
+          "cgroup2"
+        ]
+      },
+      "/sys/fs/pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "pstore"
+        ]
+      },
+      "/sys/fs/bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "devices": [
+          "bpf"
+        ]
+      },
+      "/proc/sys/fs/binfmt_misc": {
+        "fs_type": "binfmt_misc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "systemd-1",
+          "binfmt_misc"
+        ]
+      },
+      "/dev/mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "mqueue"
+        ]
+      },
+      "/dev/hugepages": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "devices": [
+          "hugetlbfs"
+        ]
+      },
+      "/sys/kernel/debug": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "debugfs"
+        ]
+      },
+      "/sys/kernel/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "tracefs"
+        ]
+      },
+      "/sys/kernel/config": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "configfs"
+        ]
+      },
+      "/sys/fs/fuse/connections": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "fusectl"
+        ]
+      }
+    },
+    "by_pair": {
+      "tmpfs,/run": {
+        "device": "tmpfs",
+        "kb_size": "401008",
+        "kb_used": "1160",
+        "kb_available": "399848",
+        "percent_used": "1%",
+        "mount": "/run",
+        "total_inodes": "501256",
+        "inodes_used": "782",
+        "inodes_available": "500474",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=401008k",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "/dev/mapper/ubuntu--vg-ubuntu--lv,/": {
+        "device": "/dev/mapper/ubuntu--vg-ubuntu--lv",
+        "kb_size": "11758760",
+        "kb_used": "4550876",
+        "kb_available": "6588776",
+        "percent_used": "41%",
+        "mount": "/",
+        "total_inodes": "753664",
+        "inodes_used": "92415",
+        "inodes_available": "661249",
+        "inodes_percent_used": "13%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "36dcbcdf-b43a-4ae3-931e-bf2a0ce14e06"
+      },
+      "tmpfs,/dev/shm": {
+        "device": "tmpfs",
+        "kb_size": "2005024",
+        "kb_used": "0",
+        "kb_available": "2005024",
+        "percent_used": "0%",
+        "mount": "/dev/shm",
+        "total_inodes": "501256",
+        "inodes_used": "1",
+        "inodes_available": "501255",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "inode64"
+        ]
+      },
+      "tmpfs,/run/lock": {
+        "device": "tmpfs",
+        "kb_size": "5120",
+        "kb_used": "0",
+        "kb_available": "5120",
+        "percent_used": "0%",
+        "mount": "/run/lock",
+        "total_inodes": "501256",
+        "inodes_used": "3",
+        "inodes_available": "501253",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k",
+          "inode64"
+        ]
+      },
+      "/dev/vda2,/boot": {
+        "device": "/dev/vda2",
+        "kb_size": "1992552",
+        "kb_used": "171460",
+        "kb_available": "1699852",
+        "percent_used": "10%",
+        "mount": "/boot",
+        "total_inodes": "131072",
+        "inodes_used": "317",
+        "inodes_available": "130755",
+        "inodes_percent_used": "1%",
+        "fs_type": "ext4",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "uuid": "0ef115d9-01b7-4521-8205-c3d8073cf019"
+      },
+      "tmpfs,/run/user/1000": {
+        "device": "tmpfs",
+        "kb_size": "401004",
+        "kb_used": "12",
+        "kb_available": "400992",
+        "percent_used": "1%",
+        "mount": "/run/user/1000",
+        "total_inodes": "100251",
+        "inodes_used": "32",
+        "inodes_available": "100219",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=401004k",
+          "nr_inodes=100251",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ]
+      },
+      "sysfs,/sys": {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "proc,/proc": {
+        "device": "proc",
+        "mount": "/proc",
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "udev,/dev": {
+        "device": "udev",
+        "mount": "/dev",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=1931232k",
+          "nr_inodes=482808",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "devpts,/dev/pts": {
+        "device": "devpts",
+        "mount": "/dev/pts",
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "securityfs,/sys/kernel/security": {
+        "device": "securityfs",
+        "mount": "/sys/kernel/security",
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "cgroup2,/sys/fs/cgroup": {
+        "device": "cgroup2",
+        "mount": "/sys/fs/cgroup",
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate",
+          "memory_recursiveprot"
+        ]
+      },
+      "pstore,/sys/fs/pstore": {
+        "device": "pstore",
+        "mount": "/sys/fs/pstore",
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "bpf,/sys/fs/bpf": {
+        "device": "bpf",
+        "mount": "/sys/fs/bpf",
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "systemd-1,/proc/sys/fs/binfmt_misc": {
+        "device": "systemd-1",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=32",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=5531"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "mount": "/dev/mqueue",
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "hugetlbfs,/dev/hugepages": {
+        "device": "hugetlbfs",
+        "mount": "/dev/hugepages",
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "pagesize=2M"
+        ]
+      },
+      "debugfs,/sys/kernel/debug": {
+        "device": "debugfs",
+        "mount": "/sys/kernel/debug",
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "tracefs,/sys/kernel/tracing": {
+        "device": "tracefs",
+        "mount": "/sys/kernel/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "configfs,/sys/kernel/config": {
+        "device": "configfs",
+        "mount": "/sys/kernel/config",
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "fusectl,/sys/fs/fuse/connections": {
+        "device": "fusectl",
+        "mount": "/sys/fs/fuse/connections",
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "binfmt_misc,/proc/sys/fs/binfmt_misc": {
+        "device": "binfmt_misc",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "binfmt_misc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/dev/sr0,": {
+        "device": "/dev/sr0"
+      },
+      "/dev/vda,": {
+        "device": "/dev/vda"
+      },
+      "/dev/vda1,": {
+        "device": "/dev/vda1"
+      },
+      "/dev/vda3,": {
+        "device": "/dev/vda3",
+        "fs_type": "LVM2_member",
+        "uuid": "F5vQHj-prYV-QT7X-2w4Y-QwfL-MWe0-kHbdxr"
+      }
+    }
+  },
+  "fips": {
+    "kernel": {
+      "enabled": false
+    }
+  },
+  "fqdn": "fauxhai.local",
+  "hostname": "Fauxhai",
+  "idle": "30 days 15 hours 07 minutes 30 seconds",
+  "idletime_seconds": 2646450,
+  "init_package": "systemd",
+  "ipaddress": "10.0.0.2",
+  "kernel": {
+    "name": "Linux",
+    "release": "6.8.0-11-generic",
+    "version": "#11-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 14 00:29:05 UTC 2024",
+    "machine": "x86_64",
+    "processor": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "tls": {
+        "size": "151552",
+        "refcount": "0"
+      },
+      "qrtr": {
+        "size": "53248",
+        "refcount": "4"
+      },
+      "cfg80211": {
+        "size": "1339392",
+        "refcount": "0"
+      },
+      "intel_rapl_msr": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "intel_rapl_common": {
+        "size": "40960",
+        "refcount": "1"
+      },
+      "intel_uncore_frequency_common": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "intel_pmc_core": {
+        "size": "118784",
+        "refcount": "0"
+      },
+      "intel_vsec": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "pmt_telemetry": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "pmt_class": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_hda_codec_generic": {
+        "size": "122880",
+        "refcount": "1"
+      },
+      "kvm_intel": {
+        "size": "487424",
+        "refcount": "0"
+      },
+      "kvm": {
+        "size": "1437696",
+        "refcount": "1"
+      },
+      "irqbypass": {
+        "size": "12288",
+        "refcount": "1"
+      },
+      "rapl": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "snd_hda_intel": {
+        "size": "61440",
+        "refcount": "0"
+      },
+      "binfmt_misc": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "snd_intel_dspcfg": {
+        "size": "36864",
+        "refcount": "1"
+      },
+      "i2c_i801": {
+        "size": "36864",
+        "refcount": "0"
+      },
+      "snd_intel_sdw_acpi": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_hda_codec": {
+        "size": "217088",
+        "refcount": "2"
+      },
+      "i2c_smbus": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_hda_core": {
+        "size": "151552",
+        "refcount": "3"
+      },
+      "snd_hwdep": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "snd_pcm": {
+        "size": "200704",
+        "refcount": "3"
+      },
+      "snd_timer": {
+        "size": "49152",
+        "refcount": "1"
+      },
+      "snd": {
+        "size": "147456",
+        "refcount": "6"
+      },
+      "soundcore": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "lpc_ich": {
+        "size": "32768",
+        "refcount": "0"
+      },
+      "joydev": {
+        "size": "32768",
+        "refcount": "0"
+      },
+      "input_leds": {
+        "size": "12288",
+        "refcount": "0"
+      },
+      "mac_hid": {
+        "size": "12288",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "dm_multipath": {
+        "size": "45056",
+        "refcount": "0"
+      },
+      "msr": {
+        "size": "12288",
+        "refcount": "0"
+      },
+      "efi_pstore": {
+        "size": "12288",
+        "refcount": "0"
+      },
+      "nfnetlink": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "dmi_sysfs": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "qemu_fw_cfg": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "ip_tables": {
+        "size": "36864",
+        "refcount": "0"
+      },
+      "x_tables": {
+        "size": "69632",
+        "refcount": "1"
+      },
+      "autofs4": {
+        "size": "57344",
+        "refcount": "2"
+      },
+      "btrfs": {
+        "size": "2015232",
+        "refcount": "0"
+      },
+      "blake2b_generic": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "raid10": {
+        "size": "73728",
+        "refcount": "0"
+      },
+      "raid456": {
+        "size": "192512",
+        "refcount": "0"
+      },
+      "async_raid6_recov": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "async_memcpy": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "async_pq": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "async_xor": {
+        "size": "16384",
+        "refcount": "3"
+      },
+      "async_tx": {
+        "size": "16384",
+        "refcount": "5"
+      },
+      "xor": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "raid6_pq": {
+        "size": "126976",
+        "refcount": "4"
+      },
+      "libcrc32c": {
+        "size": "12288",
+        "refcount": "2"
+      },
+      "raid1": {
+        "size": "57344",
+        "refcount": "0"
+      },
+      "raid0": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "hid_generic": {
+        "size": "12288",
+        "refcount": "0"
+      },
+      "usbhid": {
+        "size": "77824",
+        "refcount": "0"
+      },
+      "hid": {
+        "size": "184320",
+        "refcount": "2"
+      },
+      "crct10dif_pclmul": {
+        "size": "12288",
+        "refcount": "1"
+      },
+      "crc32_pclmul": {
+        "size": "12288",
+        "refcount": "0"
+      },
+      "polyval_clmulni": {
+        "size": "12288",
+        "refcount": "0"
+      },
+      "polyval_generic": {
+        "size": "12288",
+        "refcount": "1"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "sha256_ssse3": {
+        "size": "32768",
+        "refcount": "0"
+      },
+      "psmouse": {
+        "size": "217088",
+        "refcount": "0"
+      },
+      "ahci": {
+        "size": "49152",
+        "refcount": "0",
+        "version": "3.0"
+      },
+      "sha1_ssse3": {
+        "size": "32768",
+        "refcount": "0"
+      },
+      "qxl": {
+        "size": "86016",
+        "refcount": "0"
+      },
+      "xhci_pci": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "drm_ttm_helper": {
+        "size": "12288",
+        "refcount": "1"
+      },
+      "libahci": {
+        "size": "57344",
+        "refcount": "1"
+      },
+      "xhci_pci_renesas": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "ttm": {
+        "size": "110592",
+        "refcount": "2"
+      },
+      "virtio_rng": {
+        "size": "12288",
+        "refcount": "0"
+      },
+      "aesni_intel": {
+        "size": "356352",
+        "refcount": "0"
+      },
+      "crypto_simd": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "cryptd": {
+        "size": "28672",
+        "refcount": "2"
+      }
+    }
+  },
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux-gnu",
+      "version": "3.1.2",
+      "release_date": "2022-04-12",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux-gnu",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux-gnu",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems"
+    },
+    "powershell": null
+  },
+  "lsb": {
+    "id": "Ubuntu",
+    "description": "Ubuntu Noble Numbat (development branch)",
+    "release": "24.04",
+    "codename": "noble"
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "machinename": "Fauxhai",
+  "memory": {
+    "total": "1048576kB"
+  },
+  "network": {
+    "interfaces": {
+      "lo": {
+        "mtu": "65536",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Loopback",
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "prefixlen": "8",
+            "netmask": "255.0.0.0",
+            "scope": "Node",
+            "ip_scope": "LOOPBACK"
+          },
+          "::1": {
+            "family": "inet6",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL LOOPBACK"
+          }
+        },
+        "state": "unknown"
+      },
+      "eth0": {
+        "type": "eth",
+        "number": "0",
+        "mtu": "1500",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Ethernet",
+        "addresses": {
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
+          },
+          "10.0.0.2": {
+            "family": "inet",
+            "prefixlen": "24",
+            "netmask": "255.255.255.0",
+            "broadcast": "10.0.0.255",
+            "scope": "Global",
+            "ip_scope": "RFC1918 PRIVATE"
+          },
+          "fe80::11:1111:1111:1111": {
+            "family": "inet6",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": [
+
+            ],
+            "ip_scope": "LINK LOCAL UNICAST"
+          }
+        },
+        "state": "up",
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "10.0.0.1"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
+            "scope": "link",
+            "proto": "kernel",
+            "src": "10.0.0.2"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ],
+        "ring_params": {
+        }
+      }
+    },
+    "default_interface": "eth0",
+    "default_gateway": "10.0.0.1"
+  },
+  "ohai_time": 1711051005.6819391,
+  "os": "linux",
+  "os_version": "6.8.0-11-generic",
+  "packages": {
+    "adduser": {
+      "version": "3.137ubuntu1",
+      "arch": "all"
+    },
+    "amd64-microcode": {
+      "version": "3.20231019.1ubuntu1",
+      "arch": "amd64"
+    },
+    "apparmor": {
+      "version": "4.0.0~alpha4-0ubuntu1",
+      "arch": "amd64"
+    },
+    "apport": {
+      "version": "2.28.0-0ubuntu1",
+      "arch": "all"
+    },
+    "apport-core-dump-handler": {
+      "version": "2.28.0-0ubuntu1",
+      "arch": "all"
+    },
+    "apport-symptoms": {
+      "version": "0.24",
+      "arch": "all"
+    },
+    "appstream": {
+      "version": "1.0.2-1",
+      "arch": "amd64"
+    },
+    "apt": {
+      "version": "2.7.12",
+      "arch": "amd64"
+    },
+    "apt-utils": {
+      "version": "2.7.12",
+      "arch": "amd64"
+    },
+    "base-files": {
+      "version": "13ubuntu7",
+      "arch": "amd64"
+    },
+    "base-passwd": {
+      "version": "3.6.3",
+      "arch": "amd64"
+    },
+    "bash": {
+      "version": "5.2.21-2ubuntu2",
+      "arch": "amd64"
+    },
+    "bash-completion": {
+      "version": "1:2.11-8",
+      "arch": "all"
+    },
+    "bc": {
+      "version": "1.07.1-3build1",
+      "arch": "amd64"
+    },
+    "bcache-tools": {
+      "version": "1.0.8-5",
+      "arch": "amd64"
+    },
+    "bind9-dnsutils": {
+      "version": "1:9.18.21-0ubuntu1",
+      "arch": "amd64"
+    },
+    "bind9-host": {
+      "version": "1:9.18.21-0ubuntu1",
+      "arch": "amd64"
+    },
+    "bind9-libs": {
+      "version": "1:9.18.21-0ubuntu1",
+      "arch": "amd64"
+    },
+    "bolt": {
+      "version": "0.9.6-2",
+      "arch": "amd64"
+    },
+    "bsdextrautils": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "bsdutils": {
+      "version": "1:2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "btrfs-progs": {
+      "version": "6.6.3-1.1",
+      "arch": "amd64"
+    },
+    "busybox-initramfs": {
+      "version": "1:1.36.1-6ubuntu1",
+      "arch": "amd64"
+    },
+    "busybox-static": {
+      "version": "1:1.36.1-6ubuntu1",
+      "arch": "amd64"
+    },
+    "byobu": {
+      "version": "6.11-0ubuntu1",
+      "arch": "all"
+    },
+    "ca-certificates": {
+      "version": "20240203",
+      "arch": "all"
+    },
+    "cloud-guest-utils": {
+      "version": "0.33-1",
+      "arch": "all"
+    },
+    "cloud-init": {
+      "version": "24.1.1-0ubuntu1",
+      "arch": "all"
+    },
+    "cloud-initramfs-copymods": {
+      "version": "0.48",
+      "arch": "all"
+    },
+    "cloud-initramfs-dyn-netconf": {
+      "version": "0.48",
+      "arch": "all"
+    },
+    "command-not-found": {
+      "version": "23.04.0",
+      "arch": "all"
+    },
+    "console-setup": {
+      "version": "1.226ubuntu1",
+      "arch": "all"
+    },
+    "console-setup-linux": {
+      "version": "1.226ubuntu1",
+      "arch": "all"
+    },
+    "coreutils": {
+      "version": "9.4-2ubuntu4",
+      "arch": "amd64"
+    },
+    "cpio": {
+      "version": "2.15+dfsg-1ubuntu1",
+      "arch": "amd64"
+    },
+    "cron": {
+      "version": "3.0pl1-184ubuntu1",
+      "arch": "amd64"
+    },
+    "cron-daemon-common": {
+      "version": "3.0pl1-184ubuntu1",
+      "arch": "all"
+    },
+    "cryptsetup": {
+      "version": "2:2.7.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "cryptsetup-bin": {
+      "version": "2:2.7.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "cryptsetup-initramfs": {
+      "version": "2:2.7.0-1ubuntu1",
+      "arch": "all"
+    },
+    "curl": {
+      "version": "8.5.0-2ubuntu2",
+      "arch": "amd64"
+    },
+    "dash": {
+      "version": "0.5.12-6ubuntu4",
+      "arch": "amd64"
+    },
+    "dbus": {
+      "version": "1.14.10-4ubuntu1",
+      "arch": "amd64"
+    },
+    "dbus-bin": {
+      "version": "1.14.10-4ubuntu1",
+      "arch": "amd64"
+    },
+    "dbus-daemon": {
+      "version": "1.14.10-4ubuntu1",
+      "arch": "amd64"
+    },
+    "dbus-session-bus-common": {
+      "version": "1.14.10-4ubuntu1",
+      "arch": "all"
+    },
+    "dbus-system-bus-common": {
+      "version": "1.14.10-4ubuntu1",
+      "arch": "all"
+    },
+    "dbus-user-session": {
+      "version": "1.14.10-4ubuntu1",
+      "arch": "amd64"
+    },
+    "debconf": {
+      "version": "1.5.86",
+      "arch": "all"
+    },
+    "debconf-i18n": {
+      "version": "1.5.86",
+      "arch": "all"
+    },
+    "debianutils": {
+      "version": "5.17",
+      "arch": "amd64"
+    },
+    "dhcpcd-base": {
+      "version": "1:10.0.6-1ubuntu1",
+      "arch": "amd64"
+    },
+    "diffutils": {
+      "version": "1:3.10-1",
+      "arch": "amd64"
+    },
+    "dirmngr": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "distro-info": {
+      "version": "1.7",
+      "arch": "amd64"
+    },
+    "distro-info-data": {
+      "version": "0.60",
+      "arch": "all"
+    },
+    "dmeventd": {
+      "version": "2:1.02.185-3ubuntu1",
+      "arch": "amd64"
+    },
+    "dmidecode": {
+      "version": "3.5-3",
+      "arch": "amd64"
+    },
+    "dmsetup": {
+      "version": "2:1.02.185-3ubuntu1",
+      "arch": "amd64"
+    },
+    "dosfstools": {
+      "version": "4.2-1.1",
+      "arch": "amd64"
+    },
+    "dpkg": {
+      "version": "1.22.4ubuntu5",
+      "arch": "amd64"
+    },
+    "dracut-install": {
+      "version": "060+5-1ubuntu2",
+      "arch": "amd64"
+    },
+    "e2fsprogs": {
+      "version": "1.47.0-2ubuntu1",
+      "arch": "amd64"
+    },
+    "e2fsprogs-l10n": {
+      "version": "1.47.0-2ubuntu1",
+      "arch": "all"
+    },
+    "eatmydata": {
+      "version": "131-1",
+      "arch": "all"
+    },
+    "ed": {
+      "version": "1.20.1-1",
+      "arch": "amd64"
+    },
+    "eject": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "ethtool": {
+      "version": "1:6.7-1",
+      "arch": "amd64"
+    },
+    "fdisk": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "file": {
+      "version": "1:5.45-2",
+      "arch": "amd64"
+    },
+    "finalrd": {
+      "version": "9build1",
+      "arch": "all"
+    },
+    "findutils": {
+      "version": "4.9.0-5",
+      "arch": "amd64"
+    },
+    "firmware-sof-signed": {
+      "version": "2023.12.1-1ubuntu1",
+      "arch": "all"
+    },
+    "fonts-lato": {
+      "version": "2.015-1",
+      "arch": "all"
+    },
+    "fonts-ubuntu-console": {
+      "version": "0.869-0ubuntu1",
+      "arch": "all"
+    },
+    "friendly-recovery": {
+      "version": "0.2.42",
+      "arch": "all"
+    },
+    "ftp": {
+      "version": "20230507-2",
+      "arch": "all"
+    },
+    "fuse3": {
+      "version": "3.14.0-5",
+      "arch": "amd64"
+    },
+    "fwupd": {
+      "version": "1.9.14-1",
+      "arch": "amd64"
+    },
+    "fwupd-signed": {
+      "version": "1.52+1.4-1",
+      "arch": "amd64"
+    },
+    "gawk": {
+      "version": "1:5.2.1-2",
+      "arch": "amd64"
+    },
+    "gcc-13-base": {
+      "version": "13.2.0-17ubuntu2",
+      "arch": "amd64"
+    },
+    "gcc-14-base": {
+      "version": "14-20240303-1ubuntu1",
+      "arch": "amd64"
+    },
+    "gdisk": {
+      "version": "1.0.10-1",
+      "arch": "amd64"
+    },
+    "gettext-base": {
+      "version": "0.21-14ubuntu1",
+      "arch": "amd64"
+    },
+    "gir1.2-girepository-2.0": {
+      "version": "1.79.1-1",
+      "arch": "amd64"
+    },
+    "gir1.2-glib-2.0": {
+      "version": "2.79.2-1~ubuntu1",
+      "arch": "amd64"
+    },
+    "gir1.2-packagekitglib-1.0": {
+      "version": "1.2.8-2",
+      "arch": "amd64"
+    },
+    "git": {
+      "version": "1:2.43.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "git-man": {
+      "version": "1:2.43.0-1ubuntu1",
+      "arch": "all"
+    },
+    "gnupg": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "all"
+    },
+    "gnupg-l10n": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "all"
+    },
+    "gnupg-utils": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "gpg": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "gpg-agent": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "gpg-wks-client": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "gpgconf": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "gpgsm": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "gpgv": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "grep": {
+      "version": "3.11-4",
+      "arch": "amd64"
+    },
+    "groff-base": {
+      "version": "1.23.0-3",
+      "arch": "amd64"
+    },
+    "grub-common": {
+      "version": "2.12-1ubuntu4",
+      "arch": "amd64"
+    },
+    "grub-gfxpayload-lists": {
+      "version": "0.7build1",
+      "arch": "amd64"
+    },
+    "grub-pc": {
+      "version": "2.12-1ubuntu4",
+      "arch": "amd64"
+    },
+    "grub-pc-bin": {
+      "version": "2.12-1ubuntu4",
+      "arch": "amd64"
+    },
+    "grub2-common": {
+      "version": "2.12-1ubuntu4",
+      "arch": "amd64"
+    },
+    "gzip": {
+      "version": "1.12-1ubuntu2",
+      "arch": "amd64"
+    },
+    "hdparm": {
+      "version": "9.65+ds-1",
+      "arch": "amd64"
+    },
+    "hostname": {
+      "version": "3.23+nmu2ubuntu1",
+      "arch": "amd64"
+    },
+    "htop": {
+      "version": "3.3.0-4",
+      "arch": "amd64"
+    },
+    "ibverbs-providers": {
+      "version": "50.0-2",
+      "arch": "amd64"
+    },
+    "inetutils-telnet": {
+      "version": "2:2.5-3ubuntu1",
+      "arch": "amd64"
+    },
+    "info": {
+      "version": "7.1-3",
+      "arch": "amd64"
+    },
+    "init": {
+      "version": "1.66ubuntu1",
+      "arch": "amd64"
+    },
+    "init-system-helpers": {
+      "version": "1.66ubuntu1",
+      "arch": "all"
+    },
+    "initramfs-tools": {
+      "version": "0.142ubuntu20",
+      "arch": "all"
+    },
+    "initramfs-tools-bin": {
+      "version": "0.142ubuntu20",
+      "arch": "amd64"
+    },
+    "initramfs-tools-core": {
+      "version": "0.142ubuntu20",
+      "arch": "all"
+    },
+    "install-info": {
+      "version": "7.1-3",
+      "arch": "amd64"
+    },
+    "intel-microcode": {
+      "version": "3.20240312.1",
+      "arch": "amd64"
+    },
+    "iproute2": {
+      "version": "6.1.0-1ubuntu2",
+      "arch": "amd64"
+    },
+    "iptables": {
+      "version": "1.8.10-3ubuntu1",
+      "arch": "amd64"
+    },
+    "iputils-ping": {
+      "version": "3:20240117-1",
+      "arch": "amd64"
+    },
+    "iputils-tracepath": {
+      "version": "3:20240117-1",
+      "arch": "amd64"
+    },
+    "iso-codes": {
+      "version": "4.16.0-1",
+      "arch": "all"
+    },
+    "iucode-tool": {
+      "version": "2.3.1-3",
+      "arch": "amd64"
+    },
+    "javascript-common": {
+      "version": "11+nmu1",
+      "arch": "all"
+    },
+    "jq": {
+      "version": "1.7.1-2",
+      "arch": "amd64"
+    },
+    "kbd": {
+      "version": "2.6.4-2ubuntu1",
+      "arch": "amd64"
+    },
+    "keyboard-configuration": {
+      "version": "1.226ubuntu1",
+      "arch": "all"
+    },
+    "keyboxd": {
+      "version": "2.4.4-2ubuntu7",
+      "arch": "amd64"
+    },
+    "klibc-utils": {
+      "version": "2.0.13-4",
+      "arch": "amd64"
+    },
+    "kmod": {
+      "version": "30+20230601-2ubuntu1",
+      "arch": "amd64"
+    },
+    "kpartx": {
+      "version": "0.9.4-5ubuntu3",
+      "arch": "amd64"
+    },
+    "krb5-locales": {
+      "version": "1.20.1-5build1",
+      "arch": "all"
+    },
+    "landscape-common": {
+      "version": "24.02-0ubuntu3",
+      "arch": "amd64"
+    },
+    "less": {
+      "version": "590-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libacl1": {
+      "version": "2.3.2-1",
+      "arch": "amd64"
+    },
+    "libaio1": {
+      "version": "0.3.113-5",
+      "arch": "amd64"
+    },
+    "libapparmor1": {
+      "version": "4.0.0~alpha4-0ubuntu1",
+      "arch": "amd64"
+    },
+    "libappstream5": {
+      "version": "1.0.2-1",
+      "arch": "amd64"
+    },
+    "libapt-pkg6.0": {
+      "version": "2.7.12",
+      "arch": "amd64"
+    },
+    "libarchive13": {
+      "version": "3.7.2-1ubuntu2",
+      "arch": "amd64"
+    },
+    "libargon2-1": {
+      "version": "0~20190702+dfsg-4",
+      "arch": "amd64"
+    },
+    "libassuan0": {
+      "version": "2.5.6-1",
+      "arch": "amd64"
+    },
+    "libatasmart4": {
+      "version": "0.19-5build2",
+      "arch": "amd64"
+    },
+    "libatm1": {
+      "version": "1:2.5.1-5",
+      "arch": "amd64"
+    },
+    "libattr1": {
+      "version": "1:2.5.2-1",
+      "arch": "amd64"
+    },
+    "libaudit-common": {
+      "version": "1:3.1.2-2",
+      "arch": "all"
+    },
+    "libaudit1": {
+      "version": "1:3.1.2-2",
+      "arch": "amd64"
+    },
+    "libblkid1": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "libblockdev-crypto3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libblockdev-fs3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libblockdev-loop3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libblockdev-mdraid3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libblockdev-nvme3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libblockdev-part3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libblockdev-swap3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libblockdev-utils3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libblockdev3": {
+      "version": "3.1.0-1",
+      "arch": "amd64"
+    },
+    "libbpf1": {
+      "version": "1:1.3.0-2",
+      "arch": "amd64"
+    },
+    "libbrotli1": {
+      "version": "1.1.0-2",
+      "arch": "amd64"
+    },
+    "libbsd0": {
+      "version": "0.11.8-1",
+      "arch": "amd64"
+    },
+    "libbytesize-common": {
+      "version": "2.10-1ubuntu1",
+      "arch": "all"
+    },
+    "libbytesize1": {
+      "version": "2.10-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libbz2-1.0": {
+      "version": "1.0.8-5ubuntu1",
+      "arch": "amd64"
+    },
+    "libc-bin": {
+      "version": "2.39-0ubuntu2",
+      "arch": "amd64"
+    },
+    "libc6": {
+      "version": "2.39-0ubuntu2",
+      "arch": "amd64"
+    },
+    "libcap-ng0": {
+      "version": "0.8.4-2",
+      "arch": "amd64"
+    },
+    "libcap2": {
+      "version": "1:2.66-5ubuntu1",
+      "arch": "amd64"
+    },
+    "libcap2-bin": {
+      "version": "1:2.66-5ubuntu1",
+      "arch": "amd64"
+    },
+    "libcbor0.10": {
+      "version": "0.10.2-1.2ubuntu1",
+      "arch": "amd64"
+    },
+    "libcom-err2": {
+      "version": "1.47.0-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libcrypt1": {
+      "version": "1:4.4.36-4",
+      "arch": "amd64"
+    },
+    "libcryptsetup12": {
+      "version": "2:2.7.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libcurl3-gnutls": {
+      "version": "8.5.0-2ubuntu2",
+      "arch": "amd64"
+    },
+    "libcurl4": {
+      "version": "8.5.0-2ubuntu2",
+      "arch": "amd64"
+    },
+    "libdb5.3": {
+      "version": "5.3.28+dfsg2-4",
+      "arch": "amd64"
+    },
+    "libdbus-1-3": {
+      "version": "1.14.10-4ubuntu1",
+      "arch": "amd64"
+    },
+    "libdbus-glib-1-2": {
+      "version": "0.112-3",
+      "arch": "amd64"
+    },
+    "libdebconfclient0": {
+      "version": "0.271ubuntu1",
+      "arch": "amd64"
+    },
+    "libdevmapper-event1.02.1": {
+      "version": "2:1.02.185-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libdevmapper1.02.1": {
+      "version": "2:1.02.185-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libdrm-common": {
+      "version": "2.4.120-2",
+      "arch": "all"
+    },
+    "libdrm2": {
+      "version": "2.4.120-2",
+      "arch": "amd64"
+    },
+    "libduktape207": {
+      "version": "2.7.0+tests-0ubuntu2",
+      "arch": "amd64"
+    },
+    "libdw1": {
+      "version": "0.190-1",
+      "arch": "amd64"
+    },
+    "libeatmydata1": {
+      "version": "131-1",
+      "arch": "amd64"
+    },
+    "libedit2": {
+      "version": "3.1-20230828-1",
+      "arch": "amd64"
+    },
+    "libefiboot1t64": {
+      "version": "38-3.1",
+      "arch": "amd64"
+    },
+    "libefivar1t64": {
+      "version": "38-3.1",
+      "arch": "amd64"
+    },
+    "libelf1": {
+      "version": "0.190-1",
+      "arch": "amd64"
+    },
+    "liberror-perl": {
+      "version": "0.17029-2",
+      "arch": "all"
+    },
+    "libestr0": {
+      "version": "0.1.11-1",
+      "arch": "amd64"
+    },
+    "libevdev2": {
+      "version": "1.13.1+dfsg-1",
+      "arch": "amd64"
+    },
+    "libevent-core-2.1-7": {
+      "version": "2.1.12-stable-9",
+      "arch": "amd64"
+    },
+    "libexpat1": {
+      "version": "2.6.0-1",
+      "arch": "amd64"
+    },
+    "libext2fs2": {
+      "version": "1.47.0-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libfastjson4": {
+      "version": "1.2304.0-1",
+      "arch": "amd64"
+    },
+    "libfdisk1": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "libffi8": {
+      "version": "3.4.6-1",
+      "arch": "amd64"
+    },
+    "libfido2-1": {
+      "version": "1.14.0-1",
+      "arch": "amd64"
+    },
+    "libflashrom1": {
+      "version": "1.3.0-2.1ubuntu1",
+      "arch": "amd64"
+    },
+    "libfreetype6": {
+      "version": "2.13.2+dfsg-1",
+      "arch": "amd64"
+    },
+    "libfribidi0": {
+      "version": "1.0.13-3",
+      "arch": "amd64"
+    },
+    "libftdi1-2": {
+      "version": "1.5-6build3",
+      "arch": "amd64"
+    },
+    "libfuse3-3": {
+      "version": "3.14.0-5",
+      "arch": "amd64"
+    },
+    "libfwupd2": {
+      "version": "1.9.14-1",
+      "arch": "amd64"
+    },
+    "libgcc-s1": {
+      "version": "14-20240303-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libgcrypt20": {
+      "version": "1.10.3-2",
+      "arch": "amd64"
+    },
+    "libgdbm-compat4": {
+      "version": "1.23-5",
+      "arch": "amd64"
+    },
+    "libgdbm6": {
+      "version": "1.23-5",
+      "arch": "amd64"
+    },
+    "libgirepository-1.0-1": {
+      "version": "1.79.1-1",
+      "arch": "amd64"
+    },
+    "libglib2.0-0": {
+      "version": "2.79.2-1~ubuntu1",
+      "arch": "amd64"
+    },
+    "libglib2.0-bin": {
+      "version": "2.79.2-1~ubuntu1",
+      "arch": "amd64"
+    },
+    "libglib2.0-data": {
+      "version": "2.79.2-1~ubuntu1",
+      "arch": "all"
+    },
+    "libgmp10": {
+      "version": "2:6.3.0+dfsg-2ubuntu4",
+      "arch": "amd64"
+    },
+    "libgnutls30": {
+      "version": "3.8.3-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libgpg-error-l10n": {
+      "version": "1.47-3build1",
+      "arch": "all"
+    },
+    "libgpg-error0": {
+      "version": "1.47-3build1",
+      "arch": "amd64"
+    },
+    "libgpgme11": {
+      "version": "1.18.0-4ubuntu1",
+      "arch": "amd64"
+    },
+    "libgpm2": {
+      "version": "1.20.7-10build1",
+      "arch": "amd64"
+    },
+    "libgssapi-krb5-2": {
+      "version": "1.20.1-5build1",
+      "arch": "amd64"
+    },
+    "libgstreamer1.0-0": {
+      "version": "1.22.10-1",
+      "arch": "amd64"
+    },
+    "libgudev-1.0-0": {
+      "version": "1:238-3",
+      "arch": "amd64"
+    },
+    "libgusb2": {
+      "version": "0.4.8-1",
+      "arch": "amd64"
+    },
+    "libhogweed6": {
+      "version": "3.9.1-2",
+      "arch": "amd64"
+    },
+    "libibverbs1": {
+      "version": "50.0-2",
+      "arch": "amd64"
+    },
+    "libicu74": {
+      "version": "74.2-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libidn2-0": {
+      "version": "2.3.7-2",
+      "arch": "amd64"
+    },
+    "libimobiledevice6": {
+      "version": "1.3.0-7.1build1",
+      "arch": "amd64"
+    },
+    "libinih1": {
+      "version": "55-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libintl-perl": {
+      "version": "1.33-1build1",
+      "arch": "all"
+    },
+    "libintl-xs-perl": {
+      "version": "1.33-1build1",
+      "arch": "amd64"
+    },
+    "libip4tc2": {
+      "version": "1.8.10-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libip6tc2": {
+      "version": "1.8.10-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libisns0": {
+      "version": "0.101-0.2",
+      "arch": "amd64"
+    },
+    "libjansson4": {
+      "version": "2.14-2",
+      "arch": "amd64"
+    },
+    "libjcat1": {
+      "version": "0.2.0-2",
+      "arch": "amd64"
+    },
+    "libjq1": {
+      "version": "1.7.1-2",
+      "arch": "amd64"
+    },
+    "libjs-jquery": {
+      "version": "3.6.1+dfsg+~3.5.14-1",
+      "arch": "all"
+    },
+    "libjson-c5": {
+      "version": "0.17-1",
+      "arch": "amd64"
+    },
+    "libjson-glib-1.0-0": {
+      "version": "1.8.0-2",
+      "arch": "amd64"
+    },
+    "libjson-glib-1.0-common": {
+      "version": "1.8.0-2",
+      "arch": "all"
+    },
+    "libk5crypto3": {
+      "version": "1.20.1-5build1",
+      "arch": "amd64"
+    },
+    "libkeyutils1": {
+      "version": "1.6.3-3",
+      "arch": "amd64"
+    },
+    "libklibc": {
+      "version": "2.0.13-4",
+      "arch": "amd64"
+    },
+    "libkmod2": {
+      "version": "30+20230601-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libkrb5-3": {
+      "version": "1.20.1-5build1",
+      "arch": "amd64"
+    },
+    "libkrb5support0": {
+      "version": "1.20.1-5build1",
+      "arch": "amd64"
+    },
+    "libksba8": {
+      "version": "1.6.6-1",
+      "arch": "amd64"
+    },
+    "libldap-common": {
+      "version": "2.6.7+dfsg-1~exp1ubuntu1",
+      "arch": "all"
+    },
+    "libldap2": {
+      "version": "2.6.7+dfsg-1~exp1ubuntu1",
+      "arch": "amd64"
+    },
+    "liblmdb0": {
+      "version": "0.9.31-1",
+      "arch": "amd64"
+    },
+    "liblocale-gettext-perl": {
+      "version": "1.07-6build1",
+      "arch": "amd64"
+    },
+    "liblvm2cmd2.03": {
+      "version": "2.03.16-3ubuntu1",
+      "arch": "amd64"
+    },
+    "liblz4-1": {
+      "version": "1.9.4-1",
+      "arch": "amd64"
+    },
+    "liblzma5": {
+      "version": "5.4.5-0.3",
+      "arch": "amd64"
+    },
+    "liblzo2-2": {
+      "version": "2.10-2build3",
+      "arch": "amd64"
+    },
+    "libmagic-mgc": {
+      "version": "1:5.45-2",
+      "arch": "amd64"
+    },
+    "libmagic1": {
+      "version": "1:5.45-2",
+      "arch": "amd64"
+    },
+    "libmaxminddb0": {
+      "version": "1.9.1-1",
+      "arch": "amd64"
+    },
+    "libmbim-glib4": {
+      "version": "1.30.0-1",
+      "arch": "amd64"
+    },
+    "libmbim-proxy": {
+      "version": "1.30.0-1",
+      "arch": "amd64"
+    },
+    "libmbim-utils": {
+      "version": "1.30.0-1",
+      "arch": "amd64"
+    },
+    "libmd0": {
+      "version": "1.1.0-2",
+      "arch": "amd64"
+    },
+    "libmm-glib0": {
+      "version": "1.22.0-3",
+      "arch": "amd64"
+    },
+    "libmnl0": {
+      "version": "1.0.5-2",
+      "arch": "amd64"
+    },
+    "libmodule-find-perl": {
+      "version": "0.16-2",
+      "arch": "all"
+    },
+    "libmodule-scandeps-perl": {
+      "version": "1.35-1",
+      "arch": "all"
+    },
+    "libmount1": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "libmpfr6": {
+      "version": "4.2.1-1",
+      "arch": "amd64"
+    },
+    "libmspack0": {
+      "version": "0.11-1",
+      "arch": "amd64"
+    },
+    "libncurses6": {
+      "version": "6.4+20240113-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libncursesw6": {
+      "version": "6.4+20240113-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libnetfilter-conntrack3": {
+      "version": "1.0.9-6",
+      "arch": "amd64"
+    },
+    "libnetplan0": {
+      "version": "0.107.1-3",
+      "arch": "amd64"
+    },
+    "libnettle8": {
+      "version": "3.9.1-2",
+      "arch": "amd64"
+    },
+    "libnewt0.52": {
+      "version": "0.52.24-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libnfnetlink0": {
+      "version": "1.0.2-2",
+      "arch": "amd64"
+    },
+    "libnftables1": {
+      "version": "1.0.9-1",
+      "arch": "amd64"
+    },
+    "libnftnl11": {
+      "version": "1.2.6-2",
+      "arch": "amd64"
+    },
+    "libnghttp2-14": {
+      "version": "1.59.0-1",
+      "arch": "amd64"
+    },
+    "libnl-3-200": {
+      "version": "3.7.0-0.3",
+      "arch": "amd64"
+    },
+    "libnl-genl-3-200": {
+      "version": "3.7.0-0.3",
+      "arch": "amd64"
+    },
+    "libnl-route-3-200": {
+      "version": "3.7.0-0.3",
+      "arch": "amd64"
+    },
+    "libnpth0": {
+      "version": "1.6-3build2",
+      "arch": "amd64"
+    },
+    "libnsl2": {
+      "version": "1.3.0-3",
+      "arch": "amd64"
+    },
+    "libnspr4": {
+      "version": "2:4.35-1.1",
+      "arch": "amd64"
+    },
+    "libnss-systemd": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "libnss3": {
+      "version": "2:3.98-1",
+      "arch": "amd64"
+    },
+    "libntfs-3g89": {
+      "version": "1:2022.10.3-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libnuma1": {
+      "version": "2.0.18-1",
+      "arch": "amd64"
+    },
+    "libnvme1": {
+      "version": "1.8-2",
+      "arch": "amd64"
+    },
+    "libonig5": {
+      "version": "6.9.9-1",
+      "arch": "amd64"
+    },
+    "libopeniscsiusr": {
+      "version": "2.1.9-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libp11-kit0": {
+      "version": "0.25.3-4ubuntu1",
+      "arch": "amd64"
+    },
+    "libpackagekit-glib2-18": {
+      "version": "1.2.8-2",
+      "arch": "amd64"
+    },
+    "libpam-cap": {
+      "version": "1:2.66-5ubuntu1",
+      "arch": "amd64"
+    },
+    "libpam-modules": {
+      "version": "1.5.2-9.1ubuntu3",
+      "arch": "amd64"
+    },
+    "libpam-modules-bin": {
+      "version": "1.5.2-9.1ubuntu3",
+      "arch": "amd64"
+    },
+    "libpam-runtime": {
+      "version": "1.5.2-9.1ubuntu3",
+      "arch": "all"
+    },
+    "libpam-systemd": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "libpam0g": {
+      "version": "1.5.2-9.1ubuntu3",
+      "arch": "amd64"
+    },
+    "libparted2": {
+      "version": "3.6-3",
+      "arch": "amd64"
+    },
+    "libpcap0.8": {
+      "version": "1.10.4-4ubuntu3",
+      "arch": "amd64"
+    },
+    "libpci3": {
+      "version": "1:3.10.0-2",
+      "arch": "amd64"
+    },
+    "libpcre2-8-0": {
+      "version": "10.42-4ubuntu1",
+      "arch": "amd64"
+    },
+    "libperl5.38": {
+      "version": "5.38.2-3",
+      "arch": "amd64"
+    },
+    "libpipeline1": {
+      "version": "1.5.7-1",
+      "arch": "amd64"
+    },
+    "libplist3": {
+      "version": "2.2.0-7",
+      "arch": "amd64"
+    },
+    "libplymouth5": {
+      "version": "24.004.60-1ubuntu3",
+      "arch": "amd64"
+    },
+    "libpng16-16": {
+      "version": "1.6.43-1",
+      "arch": "amd64"
+    },
+    "libpolkit-agent-1-0": {
+      "version": "124-1",
+      "arch": "amd64"
+    },
+    "libpolkit-gobject-1-0": {
+      "version": "124-1",
+      "arch": "amd64"
+    },
+    "libpopt0": {
+      "version": "1.19+dfsg-1",
+      "arch": "amd64"
+    },
+    "libproc-processtable-perl": {
+      "version": "0.636-1build1",
+      "arch": "amd64"
+    },
+    "libproc2-0": {
+      "version": "2:4.0.4-4ubuntu1",
+      "arch": "amd64"
+    },
+    "libprotobuf-c1": {
+      "version": "1.4.1-1ubuntu2",
+      "arch": "amd64"
+    },
+    "libpsl5": {
+      "version": "0.21.2-1build1",
+      "arch": "amd64"
+    },
+    "libpython3-stdlib": {
+      "version": "3.12.1-0ubuntu2",
+      "arch": "amd64"
+    },
+    "libpython3.12": {
+      "version": "3.12.2-1",
+      "arch": "amd64"
+    },
+    "libpython3.12-minimal": {
+      "version": "3.12.2-1",
+      "arch": "amd64"
+    },
+    "libpython3.12-stdlib": {
+      "version": "3.12.2-1",
+      "arch": "amd64"
+    },
+    "libqmi-glib5": {
+      "version": "1.34.0-2",
+      "arch": "amd64"
+    },
+    "libqmi-proxy": {
+      "version": "1.34.0-2",
+      "arch": "amd64"
+    },
+    "libqmi-utils": {
+      "version": "1.34.0-2",
+      "arch": "amd64"
+    },
+    "libqrtr-glib0": {
+      "version": "1.2.2-1ubuntu2",
+      "arch": "amd64"
+    },
+    "libreadline8": {
+      "version": "8.2-3",
+      "arch": "amd64"
+    },
+    "libreiserfscore0": {
+      "version": "1:3.6.27-7",
+      "arch": "amd64"
+    },
+    "librtmp1": {
+      "version": "2.4+20151223.gitfa8646d.1-2build4",
+      "arch": "amd64"
+    },
+    "libruby": {
+      "version": "1:3.1+1",
+      "arch": "amd64"
+    },
+    "libruby3.1": {
+      "version": "3.1.2-7ubuntu4",
+      "arch": "amd64"
+    },
+    "libsasl2-2": {
+      "version": "2.1.28+dfsg1-4",
+      "arch": "amd64"
+    },
+    "libsasl2-modules": {
+      "version": "2.1.28+dfsg1-4",
+      "arch": "amd64"
+    },
+    "libsasl2-modules-db": {
+      "version": "2.1.28+dfsg1-4",
+      "arch": "amd64"
+    },
+    "libseccomp2": {
+      "version": "2.5.5-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libselinux1": {
+      "version": "3.5-2build1",
+      "arch": "amd64"
+    },
+    "libsemanage-common": {
+      "version": "3.5-1build2",
+      "arch": "all"
+    },
+    "libsemanage2": {
+      "version": "3.5-1build2",
+      "arch": "amd64"
+    },
+    "libsensors-config": {
+      "version": "1:3.6.0-9",
+      "arch": "all"
+    },
+    "libsensors5": {
+      "version": "1:3.6.0-9",
+      "arch": "amd64"
+    },
+    "libsepol2": {
+      "version": "3.5-2",
+      "arch": "amd64"
+    },
+    "libsgutils2-1.46-2": {
+      "version": "1.46-3ubuntu3",
+      "arch": "amd64"
+    },
+    "libsigsegv2": {
+      "version": "2.14-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libslang2": {
+      "version": "2.3.3-3",
+      "arch": "amd64"
+    },
+    "libsmartcols1": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "libsodium23": {
+      "version": "1.0.18-1build2",
+      "arch": "amd64"
+    },
+    "libsort-naturally-perl": {
+      "version": "1.03-4",
+      "arch": "all"
+    },
+    "libsqlite3-0": {
+      "version": "3.45.1-1",
+      "arch": "amd64"
+    },
+    "libss2": {
+      "version": "1.47.0-2ubuntu1",
+      "arch": "amd64"
+    },
+    "libssh-4": {
+      "version": "0.10.6-2",
+      "arch": "amd64"
+    },
+    "libssl3": {
+      "version": "3.0.10-1ubuntu4",
+      "arch": "amd64"
+    },
+    "libstdc++6": {
+      "version": "14-20240303-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libstemmer0d": {
+      "version": "2.2.0-4",
+      "arch": "amd64"
+    },
+    "libsystemd-shared": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "libsystemd0": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "libtasn1-6": {
+      "version": "4.19.0-3",
+      "arch": "amd64"
+    },
+    "libtcl8.6": {
+      "version": "8.6.13+dfsg-2",
+      "arch": "amd64"
+    },
+    "libterm-readkey-perl": {
+      "version": "2.38-2build2",
+      "arch": "amd64"
+    },
+    "libtext-charwidth-perl": {
+      "version": "0.04-11build1",
+      "arch": "amd64"
+    },
+    "libtext-iconv-perl": {
+      "version": "1.7-8build1",
+      "arch": "amd64"
+    },
+    "libtext-wrapi18n-perl": {
+      "version": "0.06-10",
+      "arch": "all"
+    },
+    "libtinfo6": {
+      "version": "6.4+20240113-1ubuntu1",
+      "arch": "amd64"
+    },
+    "libtirpc-common": {
+      "version": "1.3.4+ds-1build1",
+      "arch": "all"
+    },
+    "libtirpc3": {
+      "version": "1.3.4+ds-1build1",
+      "arch": "amd64"
+    },
+    "libtss2-esys-3.0.2-0": {
+      "version": "4.0.1-7ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-mu-4.0.1-0": {
+      "version": "4.0.1-7ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-sys1": {
+      "version": "4.0.1-7ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-tcti-cmd0": {
+      "version": "4.0.1-7ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-tcti-device0": {
+      "version": "4.0.1-7ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-tcti-mssim0": {
+      "version": "4.0.1-7ubuntu1",
+      "arch": "amd64"
+    },
+    "libtss2-tcti-swtpm0": {
+      "version": "4.0.1-7ubuntu1",
+      "arch": "amd64"
+    },
+    "libuchardet0": {
+      "version": "0.0.8-1",
+      "arch": "amd64"
+    },
+    "libudev1": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "libudisks2-0": {
+      "version": "2.10.1-1ubuntu2",
+      "arch": "amd64"
+    },
+    "libunistring5": {
+      "version": "1.1-2",
+      "arch": "amd64"
+    },
+    "libunwind8": {
+      "version": "1.6.2-3",
+      "arch": "amd64"
+    },
+    "libupower-glib3": {
+      "version": "1.90.2-8",
+      "arch": "amd64"
+    },
+    "liburcu8": {
+      "version": "0.14.0-3",
+      "arch": "amd64"
+    },
+    "libusb-1.0-0": {
+      "version": "2:1.0.26-1",
+      "arch": "amd64"
+    },
+    "libusbmuxd6": {
+      "version": "2.0.2-4",
+      "arch": "amd64"
+    },
+    "libutempter0": {
+      "version": "1.2.1-3",
+      "arch": "amd64"
+    },
+    "libuuid1": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "libuv1": {
+      "version": "1.48.0-1",
+      "arch": "amd64"
+    },
+    "libvolume-key1": {
+      "version": "0.3.12-5build2",
+      "arch": "amd64"
+    },
+    "libwrap0": {
+      "version": "7.6.q-32",
+      "arch": "amd64"
+    },
+    "libx11-6": {
+      "version": "2:1.8.7-1",
+      "arch": "amd64"
+    },
+    "libx11-data": {
+      "version": "2:1.8.7-1",
+      "arch": "all"
+    },
+    "libxau6": {
+      "version": "1:1.0.9-1build5",
+      "arch": "amd64"
+    },
+    "libxcb1": {
+      "version": "1.15-1",
+      "arch": "amd64"
+    },
+    "libxdmcp6": {
+      "version": "1:1.1.3-0ubuntu5",
+      "arch": "amd64"
+    },
+    "libxext6": {
+      "version": "2:1.3.4-1build1",
+      "arch": "amd64"
+    },
+    "libxkbcommon0": {
+      "version": "1.6.0-1",
+      "arch": "amd64"
+    },
+    "libxml2": {
+      "version": "2.9.14+dfsg-1.3ubuntu1",
+      "arch": "amd64"
+    },
+    "libxmlb2": {
+      "version": "0.3.15-1",
+      "arch": "amd64"
+    },
+    "libxmlsec1": {
+      "version": "1.2.38-1",
+      "arch": "amd64"
+    },
+    "libxmlsec1-openssl": {
+      "version": "1.2.38-1",
+      "arch": "amd64"
+    },
+    "libxmuu1": {
+      "version": "2:1.1.3-3",
+      "arch": "amd64"
+    },
+    "libxslt1.1": {
+      "version": "1.1.35-1",
+      "arch": "amd64"
+    },
+    "libxtables12": {
+      "version": "1.8.10-3ubuntu1",
+      "arch": "amd64"
+    },
+    "libxxhash0": {
+      "version": "0.8.2-2",
+      "arch": "amd64"
+    },
+    "libyajl-dev": {
+      "version": "2.1.0-5",
+      "arch": "amd64"
+    },
+    "libyajl2": {
+      "version": "2.1.0-5",
+      "arch": "amd64"
+    },
+    "libyaml-0-2": {
+      "version": "0.2.5-1",
+      "arch": "amd64"
+    },
+    "libzstd1": {
+      "version": "1.5.5+dfsg2-2",
+      "arch": "amd64"
+    },
+    "linux-base": {
+      "version": "4.5ubuntu9",
+      "arch": "all"
+    },
+    "linux-firmware": {
+      "version": "20240318.git3b128b60-0ubuntu1",
+      "arch": "amd64"
+    },
+    "linux-generic": {
+      "version": "6.8.0-11.11+1",
+      "arch": "amd64"
+    },
+    "linux-headers-6.8.0-11": {
+      "version": "6.8.0-11.11",
+      "arch": "all"
+    },
+    "linux-headers-6.8.0-11-generic": {
+      "version": "6.8.0-11.11",
+      "arch": "amd64"
+    },
+    "linux-headers-generic": {
+      "version": "6.8.0-11.11+1",
+      "arch": "amd64"
+    },
+    "linux-image-6.8.0-11-generic": {
+      "version": "6.8.0-11.11",
+      "arch": "amd64"
+    },
+    "linux-image-generic": {
+      "version": "6.8.0-11.11+1",
+      "arch": "amd64"
+    },
+    "linux-modules-6.8.0-11-generic": {
+      "version": "6.8.0-11.11",
+      "arch": "amd64"
+    },
+    "linux-modules-extra-6.8.0-11-generic": {
+      "version": "6.8.0-11.11",
+      "arch": "amd64"
+    },
+    "locales": {
+      "version": "2.39-0ubuntu2",
+      "arch": "all"
+    },
+    "login": {
+      "version": "1:4.13+dfsg1-4ubuntu1",
+      "arch": "amd64"
+    },
+    "logrotate": {
+      "version": "3.21.0-2",
+      "arch": "amd64"
+    },
+    "logsave": {
+      "version": "1.47.0-2ubuntu1",
+      "arch": "amd64"
+    },
+    "lsb-base": {
+      "version": "11.6",
+      "arch": "all"
+    },
+    "lsb-release": {
+      "version": "12.0-2",
+      "arch": "all"
+    },
+    "lshw": {
+      "version": "02.19.git.2021.06.19.996aaad9c7-2build1",
+      "arch": "amd64"
+    },
+    "lsof": {
+      "version": "4.95.0-1build1",
+      "arch": "amd64"
+    },
+    "lvm2": {
+      "version": "2.03.16-3ubuntu1",
+      "arch": "amd64"
+    },
+    "lxd-agent-loader": {
+      "version": "0.6",
+      "arch": "all"
+    },
+    "lxd-installer": {
+      "version": "4",
+      "arch": "all"
+    },
+    "man-db": {
+      "version": "2.12.0-3",
+      "arch": "amd64"
+    },
+    "manpages": {
+      "version": "6.05.01-1",
+      "arch": "all"
+    },
+    "mawk": {
+      "version": "1.3.4.20240123-1",
+      "arch": "amd64"
+    },
+    "mdadm": {
+      "version": "4.3-1ubuntu1",
+      "arch": "amd64"
+    },
+    "media-types": {
+      "version": "10.1.0",
+      "arch": "all"
+    },
+    "modemmanager": {
+      "version": "1.22.0-3",
+      "arch": "amd64"
+    },
+    "motd-news-config": {
+      "version": "13ubuntu7",
+      "arch": "all"
+    },
+    "mount": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "mtr-tiny": {
+      "version": "0.95-1.1",
+      "arch": "amd64"
+    },
+    "multipath-tools": {
+      "version": "0.9.4-5ubuntu3",
+      "arch": "amd64"
+    },
+    "nano": {
+      "version": "7.2-2",
+      "arch": "amd64"
+    },
+    "ncurses-base": {
+      "version": "6.4+20240113-1ubuntu1",
+      "arch": "all"
+    },
+    "ncurses-bin": {
+      "version": "6.4+20240113-1ubuntu1",
+      "arch": "amd64"
+    },
+    "ncurses-term": {
+      "version": "6.4+20240113-1ubuntu1",
+      "arch": "all"
+    },
+    "needrestart": {
+      "version": "3.6-7ubuntu3",
+      "arch": "all"
+    },
+    "netbase": {
+      "version": "6.4",
+      "arch": "all"
+    },
+    "netcat-openbsd": {
+      "version": "1.226-1ubuntu1",
+      "arch": "amd64"
+    },
+    "netplan-generator": {
+      "version": "0.107.1-3",
+      "arch": "amd64"
+    },
+    "netplan.io": {
+      "version": "0.107.1-3",
+      "arch": "amd64"
+    },
+    "networkd-dispatcher": {
+      "version": "2.2.4-1",
+      "arch": "all"
+    },
+    "nftables": {
+      "version": "1.0.9-1",
+      "arch": "amd64"
+    },
+    "ntfs-3g": {
+      "version": "1:2022.10.3-1ubuntu1",
+      "arch": "amd64"
+    },
+    "numactl": {
+      "version": "2.0.18-1",
+      "arch": "amd64"
+    },
+    "ohai": {
+      "version": "18.1.3-2",
+      "arch": "all"
+    },
+    "open-iscsi": {
+      "version": "2.1.9-3ubuntu1",
+      "arch": "amd64"
+    },
+    "open-vm-tools": {
+      "version": "2:12.3.5-4",
+      "arch": "amd64"
+    },
+    "openssh-client": {
+      "version": "1:9.6p1-3ubuntu2",
+      "arch": "amd64"
+    },
+    "openssh-server": {
+      "version": "1:9.6p1-3ubuntu2",
+      "arch": "amd64"
+    },
+    "openssh-sftp-server": {
+      "version": "1:9.6p1-3ubuntu2",
+      "arch": "amd64"
+    },
+    "openssl": {
+      "version": "3.0.10-1ubuntu4",
+      "arch": "amd64"
+    },
+    "os-prober": {
+      "version": "1.81ubuntu3",
+      "arch": "amd64"
+    },
+    "overlayroot": {
+      "version": "0.48",
+      "arch": "all"
+    },
+    "packagekit": {
+      "version": "1.2.8-2",
+      "arch": "amd64"
+    },
+    "packagekit-tools": {
+      "version": "1.2.8-2",
+      "arch": "amd64"
+    },
+    "parted": {
+      "version": "3.6-3",
+      "arch": "amd64"
+    },
+    "passwd": {
+      "version": "1:4.13+dfsg1-4ubuntu1",
+      "arch": "amd64"
+    },
+    "pastebinit": {
+      "version": "1.6.2-1",
+      "arch": "all"
+    },
+    "patch": {
+      "version": "2.7.6-7build2",
+      "arch": "amd64"
+    },
+    "pci.ids": {
+      "version": "0.0~2024.02.02-1",
+      "arch": "all"
+    },
+    "pciutils": {
+      "version": "1:3.10.0-2",
+      "arch": "amd64"
+    },
+    "perl": {
+      "version": "5.38.2-3",
+      "arch": "amd64"
+    },
+    "perl-base": {
+      "version": "5.38.2-3",
+      "arch": "amd64"
+    },
+    "perl-modules-5.38": {
+      "version": "5.38.2-3",
+      "arch": "all"
+    },
+    "pinentry-curses": {
+      "version": "1.2.1-3ubuntu1",
+      "arch": "amd64"
+    },
+    "plymouth": {
+      "version": "24.004.60-1ubuntu3",
+      "arch": "amd64"
+    },
+    "plymouth-theme-ubuntu-text": {
+      "version": "24.004.60-1ubuntu3",
+      "arch": "amd64"
+    },
+    "polkitd": {
+      "version": "124-1",
+      "arch": "amd64"
+    },
+    "pollinate": {
+      "version": "4.33-3.1ubuntu1",
+      "arch": "all"
+    },
+    "powermgmt-base": {
+      "version": "1.37",
+      "arch": "all"
+    },
+    "procps": {
+      "version": "2:4.0.4-4ubuntu1",
+      "arch": "amd64"
+    },
+    "psmisc": {
+      "version": "23.6-2",
+      "arch": "amd64"
+    },
+    "publicsuffix": {
+      "version": "20231001.0357-0.1",
+      "arch": "all"
+    },
+    "python-apt-common": {
+      "version": "2.7.6",
+      "arch": "all"
+    },
+    "python-babel-localedata": {
+      "version": "2.10.3-3build1",
+      "arch": "all"
+    },
+    "python3": {
+      "version": "3.12.1-0ubuntu2",
+      "arch": "amd64"
+    },
+    "python3-apport": {
+      "version": "2.28.0-0ubuntu1",
+      "arch": "all"
+    },
+    "python3-apt": {
+      "version": "2.7.6",
+      "arch": "amd64"
+    },
+    "python3-attr": {
+      "version": "23.2.0-2",
+      "arch": "all"
+    },
+    "python3-automat": {
+      "version": "22.10.0-2",
+      "arch": "all"
+    },
+    "python3-babel": {
+      "version": "2.10.3-3build1",
+      "arch": "all"
+    },
+    "python3-bcrypt": {
+      "version": "3.2.2-1",
+      "arch": "amd64"
+    },
+    "python3-blinker": {
+      "version": "1.7.0-1",
+      "arch": "all"
+    },
+    "python3-certifi": {
+      "version": "2023.11.17-1",
+      "arch": "all"
+    },
+    "python3-cffi-backend": {
+      "version": "1.16.0-2",
+      "arch": "amd64"
+    },
+    "python3-chardet": {
+      "version": "5.2.0+dfsg-1",
+      "arch": "all"
+    },
+    "python3-click": {
+      "version": "8.1.6-1",
+      "arch": "all"
+    },
+    "python3-colorama": {
+      "version": "0.4.6-4",
+      "arch": "all"
+    },
+    "python3-commandnotfound": {
+      "version": "23.04.0",
+      "arch": "all"
+    },
+    "python3-configobj": {
+      "version": "5.0.8-3",
+      "arch": "all"
+    },
+    "python3-constantly": {
+      "version": "23.10.4-1",
+      "arch": "all"
+    },
+    "python3-cryptography": {
+      "version": "41.0.7-3",
+      "arch": "amd64"
+    },
+    "python3-dbus": {
+      "version": "1.3.2-5build1",
+      "arch": "amd64"
+    },
+    "python3-debconf": {
+      "version": "1.5.86",
+      "arch": "all"
+    },
+    "python3-debian": {
+      "version": "0.1.49ubuntu2",
+      "arch": "all"
+    },
+    "python3-distro": {
+      "version": "1.9.0-1",
+      "arch": "all"
+    },
+    "python3-distro-info": {
+      "version": "1.7",
+      "arch": "all"
+    },
+    "python3-distupgrade": {
+      "version": "1:24.04.7",
+      "arch": "all"
+    },
+    "python3-distutils": {
+      "version": "3.11.5-1",
+      "arch": "all"
+    },
+    "python3-gdbm": {
+      "version": "3.11.5-1",
+      "arch": "amd64"
+    },
+    "python3-gi": {
+      "version": "3.47.0-3",
+      "arch": "amd64"
+    },
+    "python3-hamcrest": {
+      "version": "2.1.0-1",
+      "arch": "all"
+    },
+    "python3-httplib2": {
+      "version": "0.20.4-3",
+      "arch": "all"
+    },
+    "python3-hyperlink": {
+      "version": "21.0.0-5",
+      "arch": "all"
+    },
+    "python3-idna": {
+      "version": "3.6-2",
+      "arch": "all"
+    },
+    "python3-incremental": {
+      "version": "22.10.0-1",
+      "arch": "all"
+    },
+    "python3-jinja2": {
+      "version": "3.1.2-1ubuntu1",
+      "arch": "all"
+    },
+    "python3-json-pointer": {
+      "version": "2.0-0ubuntu1",
+      "arch": "all"
+    },
+    "python3-jsonpatch": {
+      "version": "1.32-3",
+      "arch": "all"
+    },
+    "python3-jsonschema": {
+      "version": "4.10.3-2ubuntu1",
+      "arch": "all"
+    },
+    "python3-jwt": {
+      "version": "2.7.0-1",
+      "arch": "all"
+    },
+    "python3-launchpadlib": {
+      "version": "1.11.0-6",
+      "arch": "all"
+    },
+    "python3-lazr.restfulclient": {
+      "version": "0.14.6-1",
+      "arch": "all"
+    },
+    "python3-lazr.uri": {
+      "version": "1.0.6-3",
+      "arch": "all"
+    },
+    "python3-lib2to3": {
+      "version": "3.11.5-1",
+      "arch": "all"
+    },
+    "python3-magic": {
+      "version": "2:0.4.27-2",
+      "arch": "all"
+    },
+    "python3-markdown-it": {
+      "version": "3.0.0-2",
+      "arch": "all"
+    },
+    "python3-markupsafe": {
+      "version": "2.1.5-1",
+      "arch": "amd64"
+    },
+    "python3-mdurl": {
+      "version": "0.1.2-1",
+      "arch": "all"
+    },
+    "python3-minimal": {
+      "version": "3.12.1-0ubuntu2",
+      "arch": "amd64"
+    },
+    "python3-netifaces": {
+      "version": "0.11.0-2build2",
+      "arch": "amd64"
+    },
+    "python3-netplan": {
+      "version": "0.107.1-3",
+      "arch": "amd64"
+    },
+    "python3-newt": {
+      "version": "0.52.24-2ubuntu1",
+      "arch": "amd64"
+    },
+    "python3-oauthlib": {
+      "version": "3.2.2-1",
+      "arch": "all"
+    },
+    "python3-openssl": {
+      "version": "23.2.0-1",
+      "arch": "all"
+    },
+    "python3-pexpect": {
+      "version": "4.9-2",
+      "arch": "all"
+    },
+    "python3-pkg-resources": {
+      "version": "68.1.2-2",
+      "arch": "all"
+    },
+    "python3-problem-report": {
+      "version": "2.28.0-0ubuntu1",
+      "arch": "all"
+    },
+    "python3-ptyprocess": {
+      "version": "0.7.0-5",
+      "arch": "all"
+    },
+    "python3-pyasn1": {
+      "version": "0.4.8-4",
+      "arch": "all"
+    },
+    "python3-pyasn1-modules": {
+      "version": "0.2.8-1",
+      "arch": "all"
+    },
+    "python3-pygments": {
+      "version": "2.17.2+dfsg-1",
+      "arch": "all"
+    },
+    "python3-pyparsing": {
+      "version": "3.1.1-1",
+      "arch": "all"
+    },
+    "python3-pyrsistent": {
+      "version": "0.20.0-1",
+      "arch": "amd64"
+    },
+    "python3-requests": {
+      "version": "2.31.0+dfsg-1ubuntu1",
+      "arch": "all"
+    },
+    "python3-rich": {
+      "version": "13.7.1-1",
+      "arch": "all"
+    },
+    "python3-serial": {
+      "version": "3.5-2",
+      "arch": "all"
+    },
+    "python3-service-identity": {
+      "version": "24.1.0-1",
+      "arch": "all"
+    },
+    "python3-setuptools": {
+      "version": "68.1.2-2",
+      "arch": "all"
+    },
+    "python3-six": {
+      "version": "1.16.0-4",
+      "arch": "all"
+    },
+    "python3-software-properties": {
+      "version": "0.99.42",
+      "arch": "all"
+    },
+    "python3-systemd": {
+      "version": "235-1build3",
+      "arch": "amd64"
+    },
+    "python3-twisted": {
+      "version": "23.10.0-2",
+      "arch": "all"
+    },
+    "python3-tz": {
+      "version": "2024.1-2",
+      "arch": "all"
+    },
+    "python3-update-manager": {
+      "version": "1:24.04.4",
+      "arch": "all"
+    },
+    "python3-urllib3": {
+      "version": "2.0.7-1",
+      "arch": "all"
+    },
+    "python3-wadllib": {
+      "version": "1.3.6-5",
+      "arch": "all"
+    },
+    "python3-xkit": {
+      "version": "0.5.0ubuntu6",
+      "arch": "all"
+    },
+    "python3-yaml": {
+      "version": "6.0.1-2",
+      "arch": "amd64"
+    },
+    "python3-zope.interface": {
+      "version": "6.1-1",
+      "arch": "amd64"
+    },
+    "python3.12": {
+      "version": "3.12.2-1",
+      "arch": "amd64"
+    },
+    "python3.12-minimal": {
+      "version": "3.12.2-1",
+      "arch": "amd64"
+    },
+    "rake": {
+      "version": "13.0.6-3",
+      "arch": "all"
+    },
+    "readline-common": {
+      "version": "8.2-3",
+      "arch": "all"
+    },
+    "rsync": {
+      "version": "3.2.7-1",
+      "arch": "amd64"
+    },
+    "rsyslog": {
+      "version": "8.2312.0-3ubuntu3",
+      "arch": "amd64"
+    },
+    "ruby": {
+      "version": "1:3.1+1",
+      "arch": "amd64"
+    },
+    "ruby-addressable": {
+      "version": "2.8.5-1",
+      "arch": "all"
+    },
+    "ruby-bcrypt-pbkdf": {
+      "version": "1.1.0-2build3",
+      "arch": "amd64"
+    },
+    "ruby-chef-config": {
+      "version": "16.12.3-2",
+      "arch": "all"
+    },
+    "ruby-chef-utils": {
+      "version": "16.12.3-2",
+      "arch": "all"
+    },
+    "ruby-ed25519": {
+      "version": "1.3.0+ds-1build3",
+      "arch": "amd64"
+    },
+    "ruby-fauxhai": {
+      "version": "7.5.0-1",
+      "arch": "all"
+    },
+    "ruby-ffi": {
+      "version": "1.16.3+dfsg-1build1",
+      "arch": "amd64"
+    },
+    "ruby-ffi-yajl": {
+      "version": "2.3.1-3build5",
+      "arch": "amd64"
+    },
+    "ruby-fuzzyurl": {
+      "version": "0.8.0-1.1",
+      "arch": "all"
+    },
+    "ruby-ipaddress": {
+      "version": "0.8.3-3",
+      "arch": "all"
+    },
+    "ruby-mixlib-cli": {
+      "version": "2.1.6-1",
+      "arch": "all"
+    },
+    "ruby-mixlib-config": {
+      "version": "3.0.6-1",
+      "arch": "all"
+    },
+    "ruby-mixlib-log": {
+      "version": "3.0.8-1",
+      "arch": "all"
+    },
+    "ruby-mixlib-shellout": {
+      "version": "3.2.5-2",
+      "arch": "all"
+    },
+    "ruby-net-scp": {
+      "version": "4.0.0-1",
+      "arch": "all"
+    },
+    "ruby-net-ssh": {
+      "version": "1:7.2.1-1",
+      "arch": "all"
+    },
+    "ruby-net-telnet": {
+      "version": "0.2.0-1",
+      "arch": "all"
+    },
+    "ruby-plist": {
+      "version": "3.7.0-1",
+      "arch": "all"
+    },
+    "ruby-public-suffix": {
+      "version": "4.0.6+ds-2",
+      "arch": "all"
+    },
+    "ruby-rubygems": {
+      "version": "3.4.20-1",
+      "arch": "all"
+    },
+    "ruby-sdbm": {
+      "version": "1.0.0-5build3",
+      "arch": "amd64"
+    },
+    "ruby-tomlrb": {
+      "version": "1.3.0-2",
+      "arch": "all"
+    },
+    "ruby-train-core": {
+      "version": "3.2.28-3",
+      "arch": "all"
+    },
+    "ruby-webrick": {
+      "version": "1.8.1-1",
+      "arch": "all"
+    },
+    "ruby-xmlrpc": {
+      "version": "0.3.2-2",
+      "arch": "all"
+    },
+    "ruby3.1": {
+      "version": "3.1.2-7ubuntu4",
+      "arch": "amd64"
+    },
+    "rubygems-integration": {
+      "version": "1.18",
+      "arch": "all"
+    },
+    "run-one": {
+      "version": "1.17-0ubuntu2",
+      "arch": "all"
+    },
+    "sbsigntool": {
+      "version": "0.9.4-3.1ubuntu4",
+      "arch": "amd64"
+    },
+    "screen": {
+      "version": "4.9.1-1",
+      "arch": "amd64"
+    },
+    "secureboot-db": {
+      "version": "1.9",
+      "arch": "amd64"
+    },
+    "sed": {
+      "version": "4.9-2",
+      "arch": "amd64"
+    },
+    "sensible-utils": {
+      "version": "0.0.22",
+      "arch": "all"
+    },
+    "sg3-utils": {
+      "version": "1.46-3ubuntu3",
+      "arch": "amd64"
+    },
+    "sg3-utils-udev": {
+      "version": "1.46-3ubuntu3",
+      "arch": "all"
+    },
+    "sgml-base": {
+      "version": "1.31",
+      "arch": "all"
+    },
+    "shared-mime-info": {
+      "version": "2.4-1",
+      "arch": "amd64"
+    },
+    "snapd": {
+      "version": "2.60.4+23.10",
+      "arch": "amd64"
+    },
+    "software-properties-common": {
+      "version": "0.99.42",
+      "arch": "all"
+    },
+    "sosreport": {
+      "version": "4.5.6-0ubuntu2",
+      "arch": "amd64"
+    },
+    "squashfs-tools": {
+      "version": "1:4.6.1-1",
+      "arch": "amd64"
+    },
+    "ssh-import-id": {
+      "version": "5.11-0ubuntu2",
+      "arch": "all"
+    },
+    "strace": {
+      "version": "6.6-0ubuntu1",
+      "arch": "amd64"
+    },
+    "sudo": {
+      "version": "1.9.15p5-3ubuntu1",
+      "arch": "amd64"
+    },
+    "sysstat": {
+      "version": "12.6.1-1ubuntu1",
+      "arch": "amd64"
+    },
+    "systemd": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "systemd-dev": {
+      "version": "255.2-3ubuntu2",
+      "arch": "all"
+    },
+    "systemd-hwe-hwdb": {
+      "version": "255.1.3",
+      "arch": "all"
+    },
+    "systemd-resolved": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "systemd-sysv": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "systemd-timesyncd": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "sysvinit-utils": {
+      "version": "3.08-6ubuntu2",
+      "arch": "amd64"
+    },
+    "tar": {
+      "version": "1.35+dfsg-3",
+      "arch": "amd64"
+    },
+    "tcl": {
+      "version": "8.6.13",
+      "arch": "amd64"
+    },
+    "tcl8.6": {
+      "version": "8.6.13+dfsg-2",
+      "arch": "amd64"
+    },
+    "tcpdump": {
+      "version": "4.99.4-3ubuntu1",
+      "arch": "amd64"
+    },
+    "telnet": {
+      "version": "0.17+2.5-3ubuntu1",
+      "arch": "all"
+    },
+    "thermald": {
+      "version": "2.5.6-2",
+      "arch": "amd64"
+    },
+    "thin-provisioning-tools": {
+      "version": "0.9.0-2ubuntu2",
+      "arch": "amd64"
+    },
+    "time": {
+      "version": "1.9-0.2",
+      "arch": "amd64"
+    },
+    "tmux": {
+      "version": "3.4-1",
+      "arch": "amd64"
+    },
+    "tnftp": {
+      "version": "20230507-2",
+      "arch": "amd64"
+    },
+    "tpm-udev": {
+      "version": "0.6ubuntu1",
+      "arch": "all"
+    },
+    "tzdata": {
+      "version": "2024a-1ubuntu1",
+      "arch": "all"
+    },
+    "ubuntu-advantage-tools": {
+      "version": "31.1",
+      "arch": "all"
+    },
+    "ubuntu-drivers-common": {
+      "version": "1:0.9.7.6",
+      "arch": "amd64"
+    },
+    "ubuntu-keyring": {
+      "version": "2023.11.28.1",
+      "arch": "all"
+    },
+    "ubuntu-minimal": {
+      "version": "1.536build1",
+      "arch": "amd64"
+    },
+    "ubuntu-pro-client": {
+      "version": "31.1",
+      "arch": "amd64"
+    },
+    "ubuntu-pro-client-l10n": {
+      "version": "31.1",
+      "arch": "amd64"
+    },
+    "ubuntu-release-upgrader-core": {
+      "version": "1:24.04.7",
+      "arch": "all"
+    },
+    "ubuntu-server": {
+      "version": "1.536build1",
+      "arch": "amd64"
+    },
+    "ubuntu-server-minimal": {
+      "version": "1.536build1",
+      "arch": "amd64"
+    },
+    "ubuntu-standard": {
+      "version": "1.536build1",
+      "arch": "amd64"
+    },
+    "ucf": {
+      "version": "3.0043+nmu1",
+      "arch": "all"
+    },
+    "udev": {
+      "version": "255.2-3ubuntu2",
+      "arch": "amd64"
+    },
+    "udisks2": {
+      "version": "2.10.1-1ubuntu2",
+      "arch": "amd64"
+    },
+    "ufw": {
+      "version": "0.36.2-5",
+      "arch": "all"
+    },
+    "unattended-upgrades": {
+      "version": "2.9.1+nmu4ubuntu1",
+      "arch": "all"
+    },
+    "unzip": {
+      "version": "6.0-28ubuntu3",
+      "arch": "amd64"
+    },
+    "update-manager-core": {
+      "version": "1:24.04.4",
+      "arch": "all"
+    },
+    "update-notifier-common": {
+      "version": "3.192.67",
+      "arch": "all"
+    },
+    "upower": {
+      "version": "1.90.2-8",
+      "arch": "amd64"
+    },
+    "usb-modeswitch": {
+      "version": "2.6.1-3ubuntu2",
+      "arch": "amd64"
+    },
+    "usb-modeswitch-data": {
+      "version": "20191128-6",
+      "arch": "all"
+    },
+    "usb.ids": {
+      "version": "2024.01.30-1",
+      "arch": "all"
+    },
+    "usbmuxd": {
+      "version": "1.1.1-3ubuntu1",
+      "arch": "amd64"
+    },
+    "usbutils": {
+      "version": "1:017-3",
+      "arch": "amd64"
+    },
+    "util-linux": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "uuid-runtime": {
+      "version": "2.39.3-6ubuntu2",
+      "arch": "amd64"
+    },
+    "vim": {
+      "version": "2:9.1.0016-1ubuntu2",
+      "arch": "amd64"
+    },
+    "vim-common": {
+      "version": "2:9.1.0016-1ubuntu2",
+      "arch": "all"
+    },
+    "vim-runtime": {
+      "version": "2:9.1.0016-1ubuntu2",
+      "arch": "all"
+    },
+    "vim-tiny": {
+      "version": "2:9.1.0016-1ubuntu2",
+      "arch": "amd64"
+    },
+    "wget": {
+      "version": "1.21.4-1ubuntu1",
+      "arch": "amd64"
+    },
+    "whiptail": {
+      "version": "0.52.24-2ubuntu1",
+      "arch": "amd64"
+    },
+    "wireless-regdb": {
+      "version": "2022.06.06-0ubuntu2",
+      "arch": "all"
+    },
+    "xauth": {
+      "version": "1:1.1.2-1",
+      "arch": "amd64"
+    },
+    "xdg-user-dirs": {
+      "version": "0.18-1",
+      "arch": "amd64"
+    },
+    "xfsprogs": {
+      "version": "6.6.0-1ubuntu1",
+      "arch": "amd64"
+    },
+    "xkb-data": {
+      "version": "2.41-2",
+      "arch": "all"
+    },
+    "xml-core": {
+      "version": "0.19",
+      "arch": "all"
+    },
+    "xxd": {
+      "version": "2:9.1.0016-1ubuntu2",
+      "arch": "amd64"
+    },
+    "xz-utils": {
+      "version": "5.4.5-0.3",
+      "arch": "amd64"
+    },
+    "zerofree": {
+      "version": "1.1.1-1build3",
+      "arch": "amd64"
+    },
+    "zip": {
+      "version": "3.0-13",
+      "arch": "amd64"
+    },
+    "zlib1g": {
+      "version": "1:1.3.dfsg-3ubuntu1",
+      "arch": "amd64"
+    },
+    "zstd": {
+      "version": "1.5.5+dfsg2-2",
+      "arch": "amd64"
+    }
+  },
+  "platform": "ubuntu",
+  "platform_family": "debian",
+  "platform_version": "24.04",
+  "root_group": "root",
+  "shard_seed": 135208802,
+  "shells": [
+    "/bin/sh",
+    "/usr/bin/sh",
+    "/bin/bash",
+    "/usr/bin/bash",
+    "/bin/rbash",
+    "/usr/bin/rbash",
+    "/usr/bin/dash",
+    "/usr/bin/screen",
+    "/usr/bin/tmux"
+  ],
+  "time": {
+    "timezone": "GMT"
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "virtualization": {
+    "systems": {
+    }
+  }
+}

--- a/platforms.json
+++ b/platforms.json
@@ -277,6 +277,10 @@
     "22.04": {
       "deprecated": false,
       "path": "lib/fauxhai/platforms/ubuntu/22.04.json"
+    },
+    "24.04": {
+      "deprecated": false,
+      "path": "lib/fauxhai/platforms/ubuntu/22.04.json"
     }
   },
   "windows": {

--- a/platforms.json
+++ b/platforms.json
@@ -280,7 +280,7 @@
     },
     "24.04": {
       "deprecated": false,
-      "path": "lib/fauxhai/platforms/ubuntu/22.04.json"
+      "path": "lib/fauxhai/platforms/ubuntu/24.04.json"
     }
   },
   "windows": {


### PR DESCRIPTION
## Description
This adds Ubuntu 24.04 (Noble Numbat). 

The fauxhai data is from a VM I ran in QEMU using Ubuntu Server's daily install media builds: 
https://cdimage.ubuntu.com/ubuntu-server/daily-live/current/

`Fauxhai.mock(platform: 'ubuntu', version: '24.04').data` seems to work.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
