### PR TITLE
CHEF-19102 - support for ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.1' ]
+        ruby: ['3.1', '3.2', '3.4']
     name: Validate JSON on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/fauxhai-chef.gemspec
+++ b/fauxhai-chef.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/fauxhai"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.files         = %w{LICENSE Gemfile fauxhai-chef.gemspec} + Dir.glob("{lib,bin}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.executables   = "fauxhai"


### PR DESCRIPTION
Add support for Ruby 3.4 and update CI pipeline

- Added Ruby 3.4 to the supported versions matrix in the CI workflow.
- Ensured compatibility with Ruby 3.4 across the project.
