### PR TITLE
Potential fix for code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -45,15 +45,16 @@ module Fauxhai
         elsif @options[:github_fetching]
           # Try loading from github (in case someone submitted a PR with a new file, but we haven't
           # yet updated the gem version). Cache the response locally so it's faster next time.
-          require "open-uri" unless defined?(OpenURI)
+          require "net/http" unless defined?(Net::HTTP)
           begin
-            response = URI.open("#{RAW_BASE}/lib/fauxhai/platforms/#{platform}/#{version}.json")
-          rescue OpenURI::HTTPError
+            uri = URI("#{RAW_BASE}/lib/fauxhai/platforms/#{platform}/#{version}.json")
+            response = Net::HTTP.get_response(uri)
+          rescue StandardError
             raise Fauxhai::Exception::InvalidPlatform.new("Could not find platform '#{platform}/#{version}' on the local disk and an HTTP error was encountered when fetching from Github. #{PLATFORM_LIST_MESSAGE}")
           end
 
-          if response.status.first.to_i == 200
-            response_body = response.read
+          if response.code.to_i == 200
+            response_body = response.body
             path = Pathname.new(filepath)
             FileUtils.mkdir_p(path.dirname)
 


### PR DESCRIPTION
Potential fix for [https://github.com/chef/fauxhai/security/code-scanning/1](https://github.com/chef/fauxhai/security/code-scanning/1)

To fix the problem, we should replace the call to `URI.open` with a safer alternative. The recommended approach is to use `URI(<uri>).open` or an HTTP client. In this case, we can use `Net::HTTP` to fetch the content from the URL, which avoids the security risks associated with `URI.open`.

We will need to:
1. Replace the `require "open-uri"` statement with `require "net/http"`.
2. Replace the `URI.open` call with a `Net::HTTP` request to fetch the content from the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
