### PR TITLE
fix GitHub fetching

### DIFF
--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -65,7 +65,7 @@ module Fauxhai
             end
             return parse_and_validate(response_body)
           else
-            raise Fauxhai::Exception::InvalidPlatform.new("Could not find platform '#{platform}/#{version}' on the local disk and an Github fetching returned http error code #{response.status.first.to_i}! #{PLATFORM_LIST_MESSAGE}")
+            raise Fauxhai::Exception::InvalidPlatform.new("Could not find platform '#{platform}/#{version}' on the local disk and an Github fetching returned http error code #{response.code}! #{PLATFORM_LIST_MESSAGE}")
           end
         else
           raise Fauxhai::Exception::InvalidPlatform.new("Could not find platform '#{platform}/#{version}' on the local disk and Github fetching is disabled! #{PLATFORM_LIST_MESSAGE}")

--- a/spec/mocker_spec.rb
+++ b/spec/mocker_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "net/http"
 
 describe Fauxhai::Mocker do
   describe "#data" do
@@ -13,6 +14,26 @@ describe Fauxhai::Mocker do
     context "with a Windows platform and version" do
       let(:options) { { platform: "windows", version: "10" } }
       its(["hostname"]) { is_expected.to eq "Fauxhai" }
+    end
+
+    context "GitHub fetching fails" do
+      let(:options) {
+        {
+          github_fetching: true,
+          platform: "doesntexist",
+          version: "1"
+        }
+      }
+
+      before do
+        allow(Net::HTTP)
+          .to receive(:get_response)
+          .and_return(Net::HTTPNotFound.new('1.1', '404', 'Not Found'))
+      end
+
+      it 'yields a InvalidPlatform exception' do
+        expect { subject }.to raise_error(Fauxhai::Exception::InvalidPlatform, /http error code 404/)
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Net::HTTPNotFound and other Net::HTTPClientError do not have a status attribute. We want to use the error code instead.

This is a regression introduced by the switch from `open-uri` to `net/http` in https://github.com/chef/fauxhai/commit/56240011b45c0c6daf9318c008704aa5fdc666d9.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
