### PR TITLE
GHCP -- Walk: ex2. Build and Test Baseline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 
 group :development do
   gem 'appbundler'
+  gem 'simplecov', require: false
 end

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -1,0 +1,173 @@
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe Fauxhai::Fetcher do
+  let(:ohai_data) { { "platform" => "ubuntu", "platform_version" => "20.04", "hostname" => "testhost" } }
+  let(:ohai_json) { ohai_data.to_json }
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:tmp_cache_dir) { File.join(tmpdir, "tmp") }
+
+  before do
+    FileUtils.mkdir_p(tmp_cache_dir)
+    allow(Fauxhai).to receive(:root).and_return(tmpdir)
+  end
+
+  after { FileUtils.remove_entry(tmpdir) }
+
+  # Helper to write a cache file for a given host/user
+  def write_cache_for(host:, user:)
+    key = Digest::SHA2.hexdigest("#{user}@#{host}")
+    path = File.join(tmp_cache_dir, key)
+    File.write(path, ohai_json)
+    path
+  end
+
+  describe "#initialize" do
+    context "with cached data (cache hit)" do
+      it "loads data from cache without SSH" do
+        write_cache_for(host: "myhost", user: "myuser")
+
+        fetcher = described_class.new(host: "myhost", user: "myuser")
+        expect(fetcher.to_hash).to eq(ohai_data)
+      end
+    end
+
+    context "with cache miss (SSH path)" do
+      let(:ssh_session) { instance_double("Net::SSH::Connection::Session") }
+
+      before do
+        stub_const("Net::SSH", Class.new)
+        allow(Net::SSH).to receive(:start).and_yield(ssh_session)
+        allow(ssh_session).to receive(:exec!).with("ohai").and_return(ohai_json)
+      end
+
+      it "fetches data via SSH and caches it" do
+        fetcher = described_class.new(host: "newhost", user: "sshuser")
+
+        expect(fetcher.to_hash).to eq(ohai_data)
+        # Verify cache was written
+        expect(fetcher.cached?).to be true
+        expect(JSON.parse(File.read(fetcher.cache_file))).to eq(ohai_data)
+      end
+    end
+
+    context "with force_cache_miss" do
+      let(:ssh_session) { instance_double("Net::SSH::Connection::Session") }
+
+      before do
+        # Pre-populate cache with stale data
+        write_cache_for(host: "refreshhost", user: "refreshuser")
+        stub_const("Net::SSH", Class.new)
+        allow(Net::SSH).to receive(:start).and_yield(ssh_session)
+        allow(ssh_session).to receive(:exec!).with("ohai").and_return({ "platform" => "fresh" }.to_json)
+      end
+
+      it "bypasses cache and fetches via SSH" do
+        fetcher = described_class.new(host: "refreshhost", user: "refreshuser", force_cache_miss: true)
+        expect(fetcher.to_hash["platform"]).to eq("fresh")
+      end
+    end
+
+    context "with a block" do
+      it "yields the data to the block" do
+        write_cache_for(host: "blockhost", user: "blockuser")
+
+        yielded = nil
+        described_class.new(host: "blockhost", user: "blockuser") { |d| yielded = d }
+        expect(yielded).to eq(ohai_data)
+      end
+    end
+
+    context "without :host" do
+      it "raises ArgumentError" do
+        expect { described_class.new(user: "nohost") }.to raise_error(ArgumentError, /:host is a required option/)
+      end
+    end
+  end
+
+  describe "#cache" do
+    it "returns parsed JSON from the cache file" do
+      write_cache_for(host: "cachehost", user: "cacheuser")
+      fetcher = described_class.new(host: "cachehost", user: "cacheuser")
+      expect(fetcher.cache).to eq(ohai_data)
+    end
+  end
+
+  describe "#cached?" do
+    it "returns true when cache file exists" do
+      write_cache_for(host: "existhost", user: "existuser")
+      fetcher = described_class.new(host: "existhost", user: "existuser")
+      expect(fetcher.cached?).to be true
+    end
+
+    it "returns false when cache file does not exist" do
+      # We need to construct a fetcher that was cached, then remove the file
+      write_cache_for(host: "gonehost", user: "goneuser")
+      fetcher = described_class.new(host: "gonehost", user: "goneuser")
+      File.delete(fetcher.cache_file)
+      expect(fetcher.cached?).to be false
+    end
+  end
+
+  describe "#cache_key" do
+    it "returns a SHA2 hex digest of user@host" do
+      write_cache_for(host: "keyhost", user: "keyuser")
+      fetcher = described_class.new(host: "keyhost", user: "keyuser")
+      expected = Digest::SHA2.hexdigest("keyuser@keyhost")
+      expect(fetcher.cache_key).to eq(expected)
+    end
+  end
+
+  describe "#cache_file" do
+    it "returns a path under Fauxhai.root/tmp/" do
+      write_cache_for(host: "pathhost", user: "pathuser")
+      fetcher = described_class.new(host: "pathhost", user: "pathuser")
+      expect(fetcher.cache_file).to start_with(File.join(tmpdir, "tmp"))
+    end
+  end
+
+  describe "#to_hash" do
+    it "returns the data as a hash" do
+      write_cache_for(host: "hashhost", user: "hashuser")
+      fetcher = described_class.new(host: "hashhost", user: "hashuser")
+      expect(fetcher.to_hash).to be_a(Hash)
+      expect(fetcher.to_hash).to eq(ohai_data)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns a string representation" do
+      write_cache_for(host: "strhost", user: "struser")
+      fetcher = described_class.new(host: "strhost", user: "struser")
+      expect(fetcher.to_s).to match(/#<Fauxhai::Fetcher @host=strhost/)
+    end
+  end
+
+  describe "#force_cache_miss?" do
+    it "returns false by default" do
+      write_cache_for(host: "defaulthost", user: "defaultuser")
+      fetcher = described_class.new(host: "defaulthost", user: "defaultuser")
+      expect(fetcher.force_cache_miss?).to be false
+    end
+
+    it "returns true when option is set" do
+      ssh_session = instance_double("Net::SSH::Connection::Session")
+      stub_const("Net::SSH", Class.new)
+      allow(Net::SSH).to receive(:start).and_yield(ssh_session)
+      allow(ssh_session).to receive(:exec!).with("ohai").and_return(ohai_json)
+
+      fetcher = described_class.new(host: "forcehost", user: "forceuser", force_cache_miss: true)
+      expect(fetcher.force_cache_miss?).to be true
+    end
+  end
+
+  describe "user fallback" do
+    it "falls back to ENV['USER'] when :user not provided" do
+      write_cache_for(host: "envhost", user: ENV["USER"])
+      fetcher = described_class.new(host: "envhost")
+      expected_key = Digest::SHA2.hexdigest("#{ENV["USER"]}@envhost")
+      expect(fetcher.cache_key).to eq(expected_key)
+    end
+  end
+end

--- a/spec/mocker_spec.rb
+++ b/spec/mocker_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 require "net/http"
+require "tmpdir"
+require "fileutils"
 
 describe Fauxhai::Mocker do
   describe "#data" do
@@ -33,6 +35,121 @@ describe Fauxhai::Mocker do
 
       it 'yields a InvalidPlatform exception' do
         expect { subject }.to raise_error(Fauxhai::Exception::InvalidPlatform, /http error code 404/)
+      end
+    end
+
+    context "with a :path option pointing to a valid JSON file" do
+      let(:tmpdir) { Dir.mktmpdir }
+      let(:json_path) { File.join(tmpdir, "custom.json") }
+
+      before do
+        File.write(json_path, { "platform" => "custom", "hostname" => "pathhost" }.to_json)
+      end
+
+      after { FileUtils.remove_entry(tmpdir) }
+
+      it "loads data from the specified path" do
+        mocker = described_class.new(path: json_path, github_fetching: false)
+        expect(mocker.data["hostname"]).to eq("pathhost")
+      end
+    end
+
+    context "with a :path option pointing to a nonexistent file" do
+      it "raises InvalidPlatform" do
+        expect {
+          described_class.new(path: "/nonexistent/fake.json", github_fetching: false).data
+        }.to raise_error(Fauxhai::Exception::InvalidPlatform, /does not exist/)
+      end
+    end
+
+    context "GitHub fetching succeeds with 200" do
+      let(:tmpdir) { Dir.mktmpdir }
+      let(:response_body) { { "platform" => "newplat", "hostname" => "ghhost" }.to_json }
+      let(:response) { instance_double(Net::HTTPOK, code: "200", body: response_body) }
+
+      before do
+        allow(Fauxhai).to receive(:root).and_return(tmpdir)
+        allow(Net::HTTP).to receive(:get_response).and_return(response)
+      end
+
+      after { FileUtils.remove_entry(tmpdir) }
+
+      it "fetches from GitHub and caches locally" do
+        mocker = described_class.new(platform: "newplat", version: "1.0", github_fetching: true)
+        expect(mocker.data["hostname"]).to eq("ghhost")
+
+        cached_path = File.join(tmpdir, "lib", "fauxhai", "platforms", "newplat", "1.0.json")
+        expect(File.exist?(cached_path)).to be true
+      end
+    end
+
+    context "GitHub fetching succeeds but write fails with EACCES" do
+      let(:tmpdir) { Dir.mktmpdir }
+      let(:response_body) { { "platform" => "noperm", "hostname" => "nopermhost" }.to_json }
+      let(:response) { instance_double(Net::HTTPOK, code: "200", body: response_body) }
+
+      before do
+        allow(Fauxhai).to receive(:root).and_return(tmpdir)
+        allow(Net::HTTP).to receive(:get_response).and_return(response)
+        allow(File).to receive(:open).and_call_original
+        allow(File).to receive(:open).with(anything, "w").and_raise(Errno::EACCES)
+      end
+
+      after { FileUtils.remove_entry(tmpdir) }
+
+      it "still returns data despite write failure" do
+        expect {
+          mocker = described_class.new(platform: "noperm", version: "1.0", github_fetching: true)
+          expect(mocker.data["hostname"]).to eq("nopermhost")
+        }.to output(/could not write/).to_stdout
+      end
+    end
+
+    context "GitHub fetching raises a network error" do
+      before do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError, "getaddrinfo failure")
+      end
+
+      it "raises InvalidPlatform with HTTP error message" do
+        expect {
+          described_class.new(platform: "neterr", version: "1.0", github_fetching: true).data
+        }.to raise_error(Fauxhai::Exception::InvalidPlatform, /HTTP error/)
+      end
+    end
+
+    context "with github_fetching disabled and unknown platform" do
+      it "raises InvalidPlatform" do
+        expect {
+          described_class.new(platform: "doesntexist", version: "1", github_fetching: false).data
+        }.to raise_error(Fauxhai::Exception::InvalidPlatform, /Github fetching is disabled/)
+      end
+    end
+
+    context "with deprecated platform data" do
+      let(:tmpdir) { Dir.mktmpdir }
+      let(:json_path) { File.join(tmpdir, "deprecated.json") }
+
+      before do
+        File.write(json_path, { "platform" => "oldos", "platform_version" => "1.0", "deprecated" => true }.to_json)
+      end
+
+      after { FileUtils.remove_entry(tmpdir) }
+
+      it "prints a deprecation warning to STDERR" do
+        expect(STDERR).to receive(:puts).with(/WARNING.*deprecated/)
+        described_class.new(path: json_path, github_fetching: false).data
+      end
+    end
+
+    context "with a block" do
+      it "yields data for override" do
+        yielded = nil
+        described_class.new(platform: "chefspec", version: "0.6.1", github_fetching: false) do |data|
+          yielded = data
+          data["custom_key"] = "custom_value"
+        end
+        expect(yielded).to be_a(Hash)
+        expect(yielded["custom_key"]).to eq("custom_value")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,10 @@
+require "simplecov"
+SimpleCov.start do
+  add_filter "/spec/"
+  add_filter "/scripts/"
+  track_files "lib/**/*.rb"
+end
+
 require "rspec"
 require "rspec/its"
 require "fauxhai"


### PR DESCRIPTION
## Summary
- Identified `lib/fauxhai/fetcher.rb` (0% coverage) and `lib/fauxhai/mocker.rb` (74.6%) as low-coverage modules
- Added 23 new tests (15 for Fetcher, 8 for Mocker) covering all uncovered paths
- Added SimpleCov to `spec_helper.rb` and `Gemfile` for coverage tracking
- Files touched: `spec/fetcher_spec.rb` (new), `spec/mocker_spec.rb` (expanded), `spec/spec_helper.rb`, `Gemfile`

## Evidence
- Tests: `bundle exec rspec` — 55 examples, 0 failures (23 new + 32 existing)
- Before/after metrics:

| Module | Before | After | Change |
|--------|--------|-------|--------|
| `lib/fauxhai/fetcher.rb` | 0.0% (0/40) | 90.0% (36/40) | +90.0% |
| `lib/fauxhai/mocker.rb` | 74.6% (44/59) | 94.9% (56/59) | +20.3% |
| **Overall** | **10.69%** (57/533) | **20.43%** (105/514) | **+9.74%** |

## Risk & Rollback
- Risk: low — test-only changes plus SimpleCov addition; no production code modified
- Rollback: revert commit 8e956ca

## Review Focus
- Verify mocks in `fetcher_spec.rb` properly isolate Net::SSH and filesystem
- Check EACCES and GitHub 200 mocker tests for determinism
- Run: `bundle exec rspec spec/fetcher_spec.rb spec/mocker_spec.rb`

## Track
- Level: Walk
- Exercise: ex1 Build & Test Coverage