### PR TITLE
CHEF-35087: Use appbundler in in hab packaging and install latest Habitat in Windows test

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -10,7 +10,6 @@ $env:HAB_REFRESH_CHANNEL = "base-2025"
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
 $Plan = 'fauxhai'
-$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '1.6.1245' }
 
 Write-Host "--- system details"
 $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
@@ -28,22 +27,8 @@ function Stop-HabProcess {
 
 # Installing Habitat
 function Install-Habitat {
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$Version
-  )
-
-  Write-Host "Downloading and installing Habitat version $Version..."
-  $installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
-  $installScriptPath = Join-Path $env:TEMP "hab-install-$Version.ps1"
-
-  Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
-  try {
-    & $installScriptPath -Version $Version
-  }
-  finally {
-    Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue
-  }
+  Write-Host "Downloading and installing Habitat..."
+  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
 
 try {
@@ -66,9 +51,9 @@ catch {
       }
   }
 
-  Install-Habitat -Version $HabitatVersion
+  Install-Habitat
   Write-Host "******************************************************************"
-  Write-Host "** What is My Hab Vewrsion after installation? $(hab --version)"
+  Write-Host "** What is My Hab Version after installation? $(hab --version)"
   Write-Host "******************************************************************"
 
 }

--- a/binstub_patch.rb
+++ b/binstub_patch.rb
@@ -1,0 +1,4 @@
+unless ENV["APPBUNDLER_ALLOW_RVM"]
+  ENV["APPBUNDLER_ALLOW_RVM"] = "true"
+  ENV["GEM_PATH"] = [File.expand_path(File.join(__dir__, "..", "vendor")), ENV["GEM_PATH"]].compact.join(File::PATH_SEPARATOR)
+end

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -106,4 +106,7 @@ function Invoke-After {
     # Remove the byproducts of compiling gems with extensions
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
+    # Remove .github directories from vendored gems to avoid shipping workflow files.
+    Get-ChildItem $pkg_prefix/vendor/gems -Filter ".github" -Directory -Recurse `
+        | Remove-Item -Recurse -Force
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -14,11 +14,17 @@ pkg_build_deps=(
 pkg_bin_dirs=(bin)
 
 do_setup_environment() {
-  build_line 'Setting GEM_HOME="$pkg_prefix/vendor"'
-  export GEM_HOME="$pkg_prefix/vendor"
+  push_runtime_env GEM_PATH "${pkg_prefix}/vendor"
 
-  build_line "Setting GEM_PATH=$GEM_HOME"
-  export GEM_PATH="$GEM_HOME"
+  set_runtime_env APPBUNDLER_ALLOW_RVM "true"
+  set_runtime_env LANG "en_US.UTF-8"
+  set_runtime_env LC_CTYPE "en_US.UTF-8"
+}
+
+do_prepare() {
+  if [[ ! -f /usr/bin/env ]]; then
+    ln -s "$(pkg_interpreter_for core/coreutils bin/env)" /usr/bin/env
+  fi
 }
 
 pkg_version() {
@@ -61,24 +67,33 @@ do_install() {
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
   gem install fauxhai-*.gem --no-document
-  set_runtime_env "GEM_PATH" "${pkg_prefix}/vendor"
-  wrap_ruby_bin
+
+  build_line "** generating binstubs for fauxhai-chef with precise version pins"
+  "$(pkg_path_for $ruby_pkg)/bin/ruby" "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" fauxhai-chef
+
+  build_line "** patching binstubs to allow running directly"
+  for binstub in ${pkg_prefix}/bin/*; do
+    sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../binstub_patch.rb" "$binstub"
+  done
+
+  fix_interpreter "${pkg_prefix}/bin/*" "$ruby_pkg" bin/ruby
+
+  rm -rf $GEM_PATH/cache/
+  rm -rf $GEM_PATH/bundler
+  rm -rf $GEM_PATH/doc
 }
-wrap_ruby_bin() {
-  local bin="$pkg_prefix/bin/$pkg_name"
-  local real_bin="$GEM_HOME/gems/fauxhai-chef-${pkg_version}/bin/fauxhai"
-  build_line "Adding wrapper $bin to $real_bin"
-  cat <<EOF > "$bin"
-#!$(pkg_path_for core/bash)/bin/bash
-set -e
-# Set binary path that allows InSpec to use non-Hab pkg binaries
-export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
-# Set Ruby paths defined from 'do_setup_environment()'
-  export GEM_HOME="$pkg_prefix/vendor"
-  export GEM_PATH="$GEM_PATH"
-exec $(pkg_path_for ${ruby_pkg})/bin/ruby $real_bin \$@
-EOF
-  chmod -v 755 "$bin"
+
+do_after() {
+  build_line "Removing .github directories from vendored gems..."
+  find "$pkg_prefix/vendor/gems" -type d -name ".github" \
+    | while read github_dir; do rm -rf "$github_dir"; done
+}
+
+do_end() {
+  if [[ "$(readlink /usr/bin/env)" = "$(pkg_interpreter_for core/coreutils bin/env)" ]]; then
+    build_line "Removing the symlink we created for '/usr/bin/env'"
+    rm /usr/bin/env
+  fi
 }
 
 


### PR DESCRIPTION
## Summary
This PR aligns fauxhai Habitat packaging and CI behavior with the berkshelf appbundler changes.

## Changes
- Updated Windows Habitat Buildkite test script to install latest Habitat instead of using a hardcoded pinned version.
- Removed hardcoded fallback Habitat version handling from the Windows Buildkite test script.
- Migrated Linux Habitat plan from manual wrapper generation to appbundler-based binstub generation.
- Added committed `binstub_patch.rb` and applied it to generated binstubs for runtime GEM_PATH bootstrapping.
- Added vendored `.github` directory cleanup in Habitat plans to avoid shipping workflow files from vendored gems.
- Added lifecycle handling in `habitat/plan.sh` for env interpreter symlink setup/cleanup used by appbundler flow.

## Files Updated
- `.expeditor/buildkite/artifact.habitat.test.ps1`
- `habitat/plan.sh`
- `habitat/plan.ps1`
- `binstub_patch.rb`
