### PR TITLE
Fix fauxhai binlink invocation failing with Gem::MissingSpecError on direct execution

### DIFF
--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,2 +1,122 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../plan.sh"
-# Reuse the default Linux plan for Linux ARM (aarch64) builds.
+export HAB_BLDR_CHANNEL="base-2025"
+export HAB_REFRESH_CHANNEL="base-2025"
+pkg_name=fauxhai
+pkg_origin=chef
+ruby_pkg="core/ruby3_4"
+pkg_description="Easily mock full ohai data"
+pkg_deps=(${ruby_pkg} core/coreutils core/bash)
+pkg_build_deps=(
+    core/make
+    core/sed
+    core/gcc
+    core/libarchive
+    )
+pkg_bin_dirs=(bin)
+
+do_setup_environment() {
+  push_runtime_env GEM_PATH "${pkg_prefix}/vendor"
+
+  set_runtime_env APPBUNDLER_ALLOW_RVM "true"
+  set_runtime_env LANG "en_US.UTF-8"
+  set_runtime_env LC_CTYPE "en_US.UTF-8"
+}
+
+do_prepare() {
+  if [[ ! -f /usr/bin/env ]]; then
+    ln -s "$(pkg_interpreter_for core/coreutils bin/env)" /usr/bin/env
+  fi
+}
+
+pkg_version() {
+  cat "$PLAN_CONTEXT/../../VERSION"
+}
+do_before() {
+  update_pkg_version
+}
+do_unpack() {
+  mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  cp -RT "$PLAN_CONTEXT"/../.. "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
+}
+do_build() {
+
+    export GEM_HOME="$pkg_prefix/vendor"
+
+    build_line "Setting GEM_PATH=$GEM_HOME"
+    export GEM_PATH="$GEM_HOME"
+    bundle config --local without integration deploy maintenance
+    bundle config --local jobs 4
+    bundle config --local retry 5
+    bundle config --local silence_root_warning 1
+    bundle install
+    gem build fauxhai-chef.gemspec
+    ruby ./cleanup_lint_roller.rb
+
+}
+do_install() {
+
+  # Copy NOTICE.TXT to the package directory
+  if [[ -f "$PLAN_CONTEXT/../../NOTICE" ]]; then
+    build_line "Copying NOTICE to package directory"
+    cp "$PLAN_CONTEXT/../../NOTICE" "$pkg_prefix/"
+  else
+    build_line "Warning: NOTICE not found at $PLAN_CONTEXT/../../NOTICE"
+  fi
+
+  export GEM_HOME="$pkg_prefix/vendor"
+
+  build_line "Setting GEM_PATH=$GEM_HOME"
+  export GEM_PATH="$GEM_HOME"
+  gem install fauxhai-*.gem --no-document
+
+  build_line "** generating binstubs for fauxhai-chef with precise version pins"
+  "$(pkg_path_for $ruby_pkg)/bin/ruby" "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" fauxhai-chef
+
+  build_line "** patching binstubs to allow running directly"
+  for binstub in ${pkg_prefix}/bin/*; do
+    sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../../binstub_patch.rb" "$binstub"
+  done
+
+  fix_interpreter "${pkg_prefix}/bin/*" "$ruby_pkg" bin/ruby
+
+  build_line "** creating wrapper for runtime environment"
+  mkdir -p "$pkg_prefix/libexec"
+  mv "$pkg_prefix/bin/fauxhai" "$pkg_prefix/libexec/fauxhai"
+  cat <<EOF > "$pkg_prefix/bin/fauxhai"
+#!$(pkg_path_for core/bash)/bin/bash
+set -e
+
+export PATH="$(pkg_path_for ${ruby_pkg})/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$pkg_prefix/vendor/bin:\$PATH"
+export GEM_HOME="$pkg_prefix/vendor"
+export GEM_PATH="$pkg_prefix/vendor"
+# Without this, appbundler's own binstub guard (unless
+# ENV["APPBUNDLER_ALLOW_RVM"] == "true") nils out GEM_HOME/GEM_PATH above
+# whenever fauxhai is invoked directly (e.g. via "hab pkg binlink") instead
+# of through "hab pkg exec", which otherwise sets this from RUNTIME_ENVIRONMENT.
+export APPBUNDLER_ALLOW_RVM="true"
+
+exec "$(pkg_path_for ${ruby_pkg})/bin/ruby" "$pkg_prefix/libexec/fauxhai" "\$@"
+EOF
+  chmod -v 755 "$pkg_prefix/bin/fauxhai"
+
+  rm -rf $GEM_PATH/cache/
+  rm -rf $GEM_PATH/bundler
+  rm -rf $GEM_PATH/doc
+}
+
+do_after() {
+  build_line "Removing .github directories from vendored gems..."
+  find "$pkg_prefix/vendor/gems" -type d -name ".github" \
+    | while read github_dir; do rm -rf "$github_dir"; done
+}
+
+do_end() {
+  if [[ "$(readlink /usr/bin/env)" = "$(pkg_interpreter_for core/coreutils bin/env)" ]]; then
+    build_line "Removing the symlink we created for '/usr/bin/env'"
+    rm /usr/bin/env
+  fi
+}
+
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
## Summary

Fixes `fauxhai` crashing with `Gem::MissingSpecError` on `aarch64-linux` when invoked directly (e.g. via `hab pkg binlink` / plain `fauxhai -v`) instead of through `hab pkg exec`. Reproduced concretely on `aarch64-linux`.

**Scope:** this change only touches `habitat/aarch64-linux/plan.sh`. The default `habitat/plan.sh` (used for `x86_64-linux`) is untouched.

## Problem

Unlike `ohai`, `fauxhai`'s plans previously binlinked the **raw appbundler-generated Ruby binstub** directly as `$pkg_prefix/bin/fauxhai` — there was no wrapper script. It relied solely on a `sed`-injected patch (`binstub_patch.rb`) to set `ENV['APPBUNDLER_ALLOW_RVM'] = 'true'` inside the binstub itself before appbundler's own guard runs.

That guard, standard appbundler boilerplate present in the generated binstub, is:

```ruby
unless defined?(Bundler) && Bundler.instance_variable_defined?("@load")
  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
  ::Gem.clear_paths
  gem "appbundler", "= 0.13.4"
  ...
```

If `APPBUNDLER_ALLOW_RVM` isn't already `"true"` in the process, this **wipes `GEM_HOME`/`GEM_PATH` to `nil`**, falling back to RubyGems' default gem path, which doesn't contain fauxhai's vendored dependency versions.

When `fauxhai` runs via `hab pkg exec`, this is masked because `hab pkg exec` loads the package's `RUNTIME_ENVIRONMENT` (which already contains `APPBUNDLER_ALLOW_RVM=true`, set via `do_setup_environment`). But when invoked directly — e.g. after `hab pkg binlink chef/fauxhai <version>` (used by `chef-workstation`'s install hook, which binlinks without going through `hab pkg exec`) — nothing sets `APPBUNDLER_ALLOW_RVM`, so the guard fires and the vendor `GEM_PATH` is lost:

```
Gem::MissingSpecError: Could not find 'addressable' (= 2.9.0) among 87 total gem(s)
Checked in 'GEM_PATH=/home/ubuntu/.local/share/gem/ruby/3.4.0:/hab/pkgs/core/ruby3_4/.../lib/ruby/gems/3.4.0'
    from /hab/pkgs/chef/fauxhai/.../bin/fauxhai:26:in '<main>'
```

Note the failing `GEM_PATH` contains **no vendor path at all** — confirming it was wiped by appbundler's own guard.

### Reproduction (aarch64-linux)

```console
$ hab pkg exec chef/fauxhai/<ver> -- fauxhai -v
9.4.24                             # works — RUNTIME_ENVIRONMENT is loaded

$ sudo hab pkg binlink chef/fauxhai/<ver>
★ Binlinked fauxhai ... to /bin/fauxhai

$ fauxhai -v
Gem::MissingSpecError: Could not find 'addressable' (= 2.9.0) ...   # fails — no RUNTIME_ENVIRONMENT
```

## Fix

Since `habitat/aarch64-linux/plan.sh` was previously just `source ../plan.sh` (reusing the default Linux plan verbatim), it's now converted into a **full standalone plan** — matching the existing convention already used by `habitat/aarch64-darwin/plan.sh` — so the fix can be scoped to `aarch64-linux` only, without touching the default `x86_64-linux` plan.

Within that standalone `aarch64-linux` plan:

1. **`PLAN_CONTEXT`-relative paths adjusted** — `NOTICE`, `binstub_patch.rb`, `VERSION`, and `do_unpack`'s source copy now use `../..` instead of `..`, since this plan lives one directory deeper (`habitat/aarch64-linux/`) than the default plan (`habitat/`).
2. **Wrapper introduced** — move the appbundler-generated binstub to `$pkg_prefix/libexec/fauxhai` and generate a small bash wrapper at `$pkg_prefix/bin/fauxhai` (the file that actually gets binlinked) that explicitly sets `GEM_HOME`, `GEM_PATH`, and — critically — `APPBUNDLER_ALLOW_RVM="true"` before `exec`'ing the Ruby binstub:
   ```bash
   #!<bash>/bin/bash
   set -e

   export PATH="<ruby>/bin:...:$pkg_prefix/vendor/bin:$PATH"
   export GEM_HOME="$pkg_prefix/vendor"
   export GEM_PATH="$pkg_prefix/vendor"
   export APPBUNDLER_ALLOW_RVM="true"

   exec "<ruby>/bin/ruby" "$pkg_prefix/libexec/fauxhai" "$@"
   ```
   This makes the binlinked `fauxhai` self-sufficient on aarch64-linux — no longer dependent on `RUNTIME_ENVIRONMENT` being loaded by `hab pkg exec`, nor on the sed injection into the binstub succeeding, to avoid appbundler's guard.
3. **`core/bash` added to `pkg_deps`** — the wrapper's shebang uses `pkg_path_for core/bash`; without an explicit dependency, a clean `hab pkg install` might not pull in `core/bash`, risking a "bad interpreter" error (caught in review, see below).
4. **`exec` line quoted** — the ruby interpreter and script paths are quoted to guard against word-splitting/globbing (caught in review, see below).

This pattern already exists in `habitat/aarch64-darwin/plan.sh` for `fauxhai` (which creates the same kind of wrapper), but that version is **also** missing the explicit `APPBUNDLER_ALLOW_RVM` export and the `core/bash` dependency — worth a follow-up there too, kept out of scope here.

## Review feedback addressed

Copilot's automated review flagged two issues on the first version of this change, both incorporated into the final commit:
- Missing `core/bash` in `pkg_deps` (undeclared dependency for the wrapper's shebang interpreter).
- Unquoted `exec` line in the wrapper (word-splitting/globbing risk).

## Testing performed

- `bash -n habitat/aarch64-linux/plan.sh` — syntactically valid.
- Confirmed `habitat/plan.sh` (default, x86_64-linux) is byte-for-byte identical to `main` — this change has zero effect on the x86_64-linux build.
- Verified the `pkg_path_for core/bash` pattern used in the new wrapper is already used identically and successfully in `ohai`'s Linux plan (unchanged, pre-existing code) across both x86_64 and aarch64 builds.
- Reproduced on an aarch64-linux EC2 instance using an existing published artifact via `hab pkg exec` (works) vs. `hab pkg binlink` + direct invocation (fails).

## Files changed

- `habitat/aarch64-linux/plan.sh` — converted from a `source ../plan.sh` shim into a full standalone plan with the fix described above.

---
This work was completed with AI assistance following Progress AI policies.

