### PR TITLE
Fix fauxhai Gem::MissingSpecError on aarch64-linux when binlinked

### DIFF
--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,2 +1,122 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../plan.sh"
-# Reuse the default Linux plan for Linux ARM (aarch64) builds.
+export HAB_BLDR_CHANNEL="base-2025"
+export HAB_REFRESH_CHANNEL="base-2025"
+pkg_name=fauxhai
+pkg_origin=chef
+ruby_pkg="core/ruby3_4"
+pkg_description="Easily mock full ohai data"
+pkg_deps=(${ruby_pkg} core/coreutils core/bash)
+pkg_build_deps=(
+    core/make
+    core/sed
+    core/gcc
+    core/libarchive
+    )
+pkg_bin_dirs=(bin)
+
+do_setup_environment() {
+  push_runtime_env GEM_PATH "${pkg_prefix}/vendor"
+
+  set_runtime_env APPBUNDLER_ALLOW_RVM "true"
+  set_runtime_env LANG "en_US.UTF-8"
+  set_runtime_env LC_CTYPE "en_US.UTF-8"
+}
+
+do_prepare() {
+  if [[ ! -f /usr/bin/env ]]; then
+    ln -s "$(pkg_interpreter_for core/coreutils bin/env)" /usr/bin/env
+  fi
+}
+
+pkg_version() {
+  cat "$PLAN_CONTEXT/../../VERSION"
+}
+do_before() {
+  update_pkg_version
+}
+do_unpack() {
+  mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  cp -RT "$PLAN_CONTEXT"/../.. "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
+}
+do_build() {
+
+    export GEM_HOME="$pkg_prefix/vendor"
+
+    build_line "Setting GEM_PATH=$GEM_HOME"
+    export GEM_PATH="$GEM_HOME"
+    bundle config --local without integration deploy maintenance
+    bundle config --local jobs 4
+    bundle config --local retry 5
+    bundle config --local silence_root_warning 1
+    bundle install
+    gem build fauxhai-chef.gemspec
+    ruby ./cleanup_lint_roller.rb
+
+}
+do_install() {
+
+  # Copy NOTICE.TXT to the package directory
+  if [[ -f "$PLAN_CONTEXT/../../NOTICE" ]]; then
+    build_line "Copying NOTICE to package directory"
+    cp "$PLAN_CONTEXT/../../NOTICE" "$pkg_prefix/"
+  else
+    build_line "Warning: NOTICE not found at $PLAN_CONTEXT/../../NOTICE"
+  fi
+
+  export GEM_HOME="$pkg_prefix/vendor"
+
+  build_line "Setting GEM_PATH=$GEM_HOME"
+  export GEM_PATH="$GEM_HOME"
+  gem install fauxhai-*.gem --no-document
+
+  build_line "** generating binstubs for fauxhai-chef with precise version pins"
+  "$(pkg_path_for $ruby_pkg)/bin/ruby" "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" fauxhai-chef
+
+  build_line "** patching binstubs to allow running directly"
+  for binstub in "${pkg_prefix}"/bin/*; do
+    sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../../binstub_patch.rb" "$binstub"
+  done
+
+  fix_interpreter "${pkg_prefix}/bin/*" "$ruby_pkg" bin/ruby
+
+  build_line "** creating wrapper for runtime environment"
+  mkdir -p "$pkg_prefix/libexec"
+  mv "$pkg_prefix/bin/fauxhai" "$pkg_prefix/libexec/fauxhai"
+  cat <<EOF > "$pkg_prefix/bin/fauxhai"
+#!$(pkg_path_for core/bash)/bin/bash
+set -e
+
+export PATH="$(pkg_path_for ${ruby_pkg})/bin:/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$pkg_prefix/vendor/bin:\$PATH"
+export GEM_HOME="$pkg_prefix/vendor"
+export GEM_PATH="$pkg_prefix/vendor"
+# Without this, appbundler's own binstub guard (unless
+# ENV["APPBUNDLER_ALLOW_RVM"] == "true") nils out GEM_HOME/GEM_PATH above
+# whenever fauxhai is invoked directly (e.g. via "hab pkg binlink") instead
+# of through "hab pkg exec", which otherwise sets this from RUNTIME_ENVIRONMENT.
+export APPBUNDLER_ALLOW_RVM="true"
+
+exec "$(pkg_path_for ${ruby_pkg})/bin/ruby" "$pkg_prefix/libexec/fauxhai" "\$@"
+EOF
+  chmod -v 755 "$pkg_prefix/bin/fauxhai"
+
+  rm -rf "${GEM_PATH:?}/cache/"
+  rm -rf "${GEM_PATH:?}/bundler"
+  rm -rf "${GEM_PATH:?}/doc"
+}
+
+do_after() {
+  build_line "Removing .github directories from vendored gems..."
+  find "$pkg_prefix/vendor/gems" -type d -name ".github" \
+    | while read github_dir; do rm -rf "$github_dir"; done
+}
+
+do_end() {
+  if [[ "$(readlink /usr/bin/env)" = "$(pkg_interpreter_for core/coreutils bin/env)" ]]; then
+    build_line "Removing the symlink we created for '/usr/bin/env'"
+    rm /usr/bin/env
+  fi
+}
+
+
+do_strip() {
+  return 0
+}


### PR DESCRIPTION
## Problem

`fauxhai` crashes with `Gem::MissingSpecError` on **aarch64-linux** when invoked directly, e.g. after `hab pkg binlink` followed by a plain `fauxhai -v`, instead of through `hab pkg exec`:

```
Gem::MissingSpecError: Could not find 'addressable' (= 2.9.0) among 87 total gem(s)
Checked in 'GEM_PATH=/home/ubuntu/.local/share/gem/ruby/3.4.0:/hab/pkgs/core/ruby3_4/.../lib/ruby/gems/3.4.0'
    from /hab/pkgs/chef/fauxhai/.../bin/fauxhai:26:in '<main>'
```

The `fauxhai` binstub is generated by `appbundler`, which embeds this guard:

```ruby
unless defined?(Bundler) && Bundler.instance_variable_defined?("@load")
  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
  ...
```

If `APPBUNDLER_ALLOW_RVM` isn't already `"true"` in the process, this wipes `GEM_HOME`/`GEM_PATH`, so RubyGems falls back to the system gem path instead of the vendored one — which is missing fauxhai's pinned dependencies.

- `hab pkg exec chef/fauxhai/<ver> -- fauxhai -v` works, because `hab pkg exec` loads the package's `RUNTIME_ENVIRONMENT`, which already sets `APPBUNDLER_ALLOW_RVM=true`.
- A raw `hab pkg binlink` (the mechanism `chef-workstation`'s install hook uses) does **not** load `RUNTIME_ENVIRONMENT`, so the guard fires and the binstub breaks when run directly.

This only reproduces on **aarch64-linux** — the x86_64-linux build is unaffected by this issue.

## Why a separate `aarch64-linux/plan.sh` is needed

`aarch64-linux` and `x86_64-linux` need genuinely different install logic here, not just different `pkg_deps`:

- The wrapper (and its `core/bash` shebang dependency) is **only required on aarch64-linux** to work around this invocation-order bug. Adding it unconditionally to the shared `x86_64-linux` plan would change behavior for a target that isn't affected, for no benefit.
- Habitat's per-target plan resolution already expects `habitat/<target>/plan.sh` to fully own that target's build/install steps — there's no supported way to conditionally branch `do_install` behavior by target from within a single shared plan file.
- Keeping the fix isolated to `habitat/aarch64-linux/plan.sh` means the default `habitat/plan.sh` (x86_64-linux) is completely untouched, minimizing risk to the working target.

## Fix

In `habitat/aarch64-linux/plan.sh`:
- Move the appbundler-generated binstub from `$pkg_prefix/bin/fauxhai` to `$pkg_prefix/libexec/fauxhai`.
- Add a small bash wrapper at `$pkg_prefix/bin/fauxhai` (the file that actually gets binlinked) that explicitly sets `GEM_HOME`, `GEM_PATH`, and `APPBUNDLER_ALLOW_RVM="true"` before `exec`-ing the Ruby binstub, so it's self-sufficient regardless of how it's invoked.
- Add `core/bash` to `pkg_deps`, since the wrapper's shebang uses `pkg_path_for core/bash`.
- Quote the `exec` line and the binstub-patching glob loop to avoid word-splitting/globbing issues.
- Use `"${GEM_PATH:?}"` guards on the `rm -rf` cleanup lines so they fail safely instead of silently operating on an empty/unset path.

## Testing

- `bash -n habitat/aarch64-linux/plan.sh` — syntactically valid.
- Confirmed `habitat/plan.sh` (default, x86_64-linux) is unchanged from `main`.
- Reproduced on an aarch64-linux host: `hab pkg exec chef/fauxhai/<ver> -- fauxhai -v` works; `hab pkg binlink` + direct `fauxhai -v` fails before this fix and succeeds after.

---
This work was completed with AI assistance following Progress AI policies.
