### PR TITLE
Fix binstub_patch.rb/NOTICE path resolution on aarch64-linux builds

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,5 +1,16 @@
 export HAB_BLDR_CHANNEL="base-2025"
 export HAB_REFRESH_CHANNEL="base-2025"
+
+# Resolve the repo root from this file's own location (BASH_SOURCE) rather
+# than PLAN_CONTEXT. PLAN_CONTEXT is set by Habitat to the directory it
+# started the build from, which is NOT necessarily the directory this file
+# lives in -- e.g. when habitat/aarch64-linux/plan.sh sources this file,
+# PLAN_CONTEXT is "habitat/aarch64-linux", not "habitat", which breaks any
+# "${PLAN_CONTEXT}/.." reference used here. BASH_SOURCE[0] always points at
+# this file, so it resolves correctly regardless of which plan sourced it.
+FAUXHAI_PLAN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FAUXHAI_REPO_ROOT="$(cd "${FAUXHAI_PLAN_DIR}/.." && pwd)"
+
 pkg_name=fauxhai
 pkg_origin=chef
 ruby_pkg="core/ruby3_4"
@@ -35,7 +46,7 @@ do_before() {
 }
 do_unpack() {
   mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  cp -RT "$PLAN_CONTEXT"/.. "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
+  cp -RT "$FAUXHAI_REPO_ROOT" "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
 }
 do_build() {
 
@@ -55,11 +66,11 @@ do_build() {
 do_install() {
 
   # Copy NOTICE.TXT to the package directory
-  if [[ -f "$PLAN_CONTEXT/../NOTICE" ]]; then
+  if [[ -f "${FAUXHAI_REPO_ROOT}/NOTICE" ]]; then
     build_line "Copying NOTICE to package directory"
-    cp "$PLAN_CONTEXT/../NOTICE" "$pkg_prefix/"
+    cp "${FAUXHAI_REPO_ROOT}/NOTICE" "$pkg_prefix/"
   else
-    build_line "Warning: NOTICE not found at $PLAN_CONTEXT/../NOTICE"
+    build_line "Warning: NOTICE not found at ${FAUXHAI_REPO_ROOT}/NOTICE"
   fi
 
   export GEM_HOME="$pkg_prefix/vendor"
@@ -72,15 +83,15 @@ do_install() {
   "$(pkg_path_for $ruby_pkg)/bin/ruby" "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" fauxhai-chef
 
   build_line "** patching binstubs to allow running directly"
-  for binstub in ${pkg_prefix}/bin/*; do
-    sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../binstub_patch.rb" "$binstub"
+  for binstub in "${pkg_prefix}"/bin/*; do
+    sed -i "/require \"rubygems\"/r ${FAUXHAI_REPO_ROOT}/binstub_patch.rb" "$binstub"
   done
 
   fix_interpreter "${pkg_prefix}/bin/*" "$ruby_pkg" bin/ruby
 
-  rm -rf $GEM_PATH/cache/
-  rm -rf $GEM_PATH/bundler
-  rm -rf $GEM_PATH/doc
+  rm -rf "${GEM_PATH:?}/cache/"
+  rm -rf "${GEM_PATH:?}/bundler"
+  rm -rf "${GEM_PATH:?}/doc"
 }
 
 do_after() {


### PR DESCRIPTION
## Problem

`fauxhai` crashes with `Gem::MissingSpecError` on **aarch64-linux** when invoked directly, e.g. after `hab pkg binlink` followed by a plain `fauxhai -v`, instead of through `hab pkg exec`:

```
Gem::MissingSpecError: Could not find 'addressable' (= 2.9.0) among 87 total gem(s)
Checked in 'GEM_PATH=/home/ubuntu/.local/share/gem/ruby/3.4.0:/hab/pkgs/core/ruby3_4/.../lib/ruby/gems/3.4.0'
    from /hab/pkgs/chef/fauxhai/.../bin/fauxhai:26:in '<main>'
```

`x86_64-linux` is unaffected.

## Root cause

`habitat/aarch64-linux/plan.sh` is a thin file that reuses the shared plan via:

```bash
source "$(dirname "${BASH_SOURCE[0]}")/../plan.sh"
```

So the exact same `do_install`/`do_unpack` code in `habitat/plan.sh` runs for both `x86_64-linux` and `aarch64-linux` builds. That shared code referenced paths relative to `$PLAN_CONTEXT`, e.g.:

```bash
sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../binstub_patch.rb" "$binstub"
```

`PLAN_CONTEXT` is **not** set to "the directory of the file currently executing" — Habitat sets it to the directory it started the build from. When building `x86_64-linux`, that's `habitat/`, so `${PLAN_CONTEXT}/..` correctly resolves to the repo root. When building `aarch64-linux`, Habitat starts from `habitat/aarch64-linux/`, so `PLAN_CONTEXT` is `habitat/aarch64-linux/` — even though the code being executed is `source`'d from `habitat/plan.sh` one directory up. `${PLAN_CONTEXT}/..` then resolves to `habitat/` instead of the repo root, so `binstub_patch.rb` is looked up at the wrong path.

Critically, `sed -i "...r <missing-file>" "$binstub"` does **not** error when the referenced file doesn't exist (or the search pattern doesn't match) — it silently does nothing and still exits `0`. So the aarch64-linux build silently shipped a `fauxhai` binstub **without** the patch that pre-sets `APPBUNDLER_ALLOW_RVM=true`. Without that patch, appbundler's own guard in the generated binstub:

```ruby
ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
```

wipes `GEM_HOME`/`GEM_PATH` whenever `fauxhai` is invoked directly (bypassing `hab pkg exec`, which sets that variable via `RUNTIME_ENVIRONMENT`) — exactly what a raw `hab pkg binlink` + direct invocation does (this is also what `chef-workstation`'s install hook uses).

The same `${PLAN_CONTEXT}/..`-relative pattern is also used for the `NOTICE` file copy and the `do_unpack` source copy, so those were silently broken/incorrect on `aarch64-linux` too.

**Verified directly:** compared the actual shipped `libexec/fauxhai`-equivalent binstub content on x86_64 vs aarch64-linux hosts — the `APPBUNDLER_ALLOW_RVM` patch block is present after `require "rubygems"` on x86_64, and completely absent on aarch64-linux, confirming the sed silently no-oped there.

## Fix

In `habitat/plan.sh` (the shared plan, used directly for x86_64-linux and sourced by aarch64-linux):

- Resolve the repo root from **this file's own location** via `BASH_SOURCE[0]` instead of `$PLAN_CONTEXT`. `BASH_SOURCE[0]` always points at `habitat/plan.sh` itself, regardless of which plan sourced it, so it resolves correctly on both targets.
- Use that resolved path (`FAUXHAI_REPO_ROOT`) for all repo-root-relative references: `binstub_patch.rb`, `NOTICE`, and the `do_unpack` source copy.
- No changes needed to `habitat/aarch64-linux/plan.sh` — it stays the thin `source ../plan.sh` shim, avoiding logic duplication/drift between targets.

Additional small hardening picked up while touching this code (no behavior change on working targets):
- Quoted the `${pkg_prefix}/bin/*` glob in the binstub-patching loop.
- Used `"${GEM_PATH:?}"` guards on the `rm -rf` cleanup lines so they fail safely instead of silently operating on an empty/unset path.

## Testing

- `bash -n habitat/plan.sh` and `bash -n habitat/aarch64-linux/plan.sh` — both syntactically valid.
- Manually sourced `habitat/plan.sh` with `PLAN_CONTEXT` deliberately set to an `aarch64-linux`-style path (reproducing the exact build-time condition) — confirmed `FAUXHAI_REPO_ROOT` still resolves to the true repo root, and both `binstub_patch.rb` and `NOTICE` are found correctly.
- This directly targets and fixes the actual root cause (path resolution), rather than working around the symptom with an extra wrapper script.

---
This work was completed with AI assistance following Progress AI policies.
